### PR TITLE
Sparkline examples

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "layerchart",
-  "version": "0.22.2",
+  "version": "0.23.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "layerchart",
-      "version": "0.22.2",
+      "version": "0.23.0",
       "license": "MIT",
       "dependencies": {
         "@changesets/cli": "^2.26.2",

--- a/src/routes/_NavMenu.svelte
+++ b/src/routes/_NavMenu.svelte
@@ -16,6 +16,7 @@
       'Line',
       'PunchCard',
       'Scatter',
+      'Sparkline',
       'Threshold',
     ],
     'Hierarchy & Graph': ['Pack', 'Partition', 'Sankey', 'Sunburst', 'Tree', 'Treemap'],

--- a/src/routes/docs/examples/Sparkline/+page.svelte
+++ b/src/routes/docs/examples/Sparkline/+page.svelte
@@ -1,14 +1,10 @@
 <script lang="ts">
-  import { scaleOrdinal, scaleTime } from 'd3-scale';
-  import { flatGroup } from 'd3-array';
+  import { scaleTime } from 'd3-scale';
   import { format } from 'date-fns';
-  import { formatDate, PeriodType } from 'svelte-ux/utils/date';
 
   import Chart, { Svg } from '$lib/components/Chart.svelte';
-  import Axis from '$lib/components/Axis.svelte';
   import Highlight from '$lib/components/Highlight.svelte';
-  import Labels from '$lib/components/Labels.svelte';
-  import Text from '$lib/components/Text.svelte';
+
   import Spline from '$lib/components/Spline.svelte';
   import Tooltip from '$lib/components/Tooltip.svelte';
   import TooltipItem from '$lib/components/TooltipItem.svelte';

--- a/src/routes/docs/examples/Sparkline/+page.svelte
+++ b/src/routes/docs/examples/Sparkline/+page.svelte
@@ -1,0 +1,108 @@
+<script lang="ts">
+  import { scaleOrdinal, scaleTime } from 'd3-scale';
+  import { flatGroup } from 'd3-array';
+  import { format } from 'date-fns';
+  import { formatDate, PeriodType } from 'svelte-ux/utils/date';
+
+  import Chart, { Svg } from '$lib/components/Chart.svelte';
+  import Axis from '$lib/components/Axis.svelte';
+  import Highlight from '$lib/components/Highlight.svelte';
+  import Labels from '$lib/components/Labels.svelte';
+  import Text from '$lib/components/Text.svelte';
+  import Spline from '$lib/components/Spline.svelte';
+  import Tooltip from '$lib/components/Tooltip.svelte';
+  import TooltipItem from '$lib/components/TooltipItem.svelte';
+
+  import Preview from '$lib/docs/Preview.svelte';
+  import { createDateSeries } from '$lib/utils/genData';
+
+  const data = createDateSeries({ count: 50, min: 50, max: 100, value: 'integer' });
+
+</script>
+
+<h1>Examples</h1>
+
+<h2>Basic</h2>
+<Preview>
+  <div>
+    <div class="w-[125px] h-[18px]">
+      <Chart
+        {data}
+        x="date"
+        xScale={scaleTime()}
+        y="value"
+        yDomain={[null, null]}
+      >
+        <Svg>
+          <Spline class="stroke-1 stroke-accent-500" />
+        </Svg>
+      </Chart>
+    </div>
+  </div>
+</Preview>
+
+
+<h2>Basic within a paragraph</h2>
+<Preview>
+  <div>
+    <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Etiam pretium, ligula ac sollicitudin ullamcorper, leo justo pretium tellus, at gravida ex quam et orci.
+    <span class="w-[125px] h-[18px] inline-block">
+      <Chart
+        {data}
+        x="date"
+        xScale={scaleTime()}
+        y="value"
+        yDomain={[null, null]}
+      >
+        <Svg>
+          <Spline class="stroke-1 stroke-accent-500" />
+        </Svg>
+      </Chart>
+    </span>  Sed ipsum justo, facilisis id tempor hendrerit, suscipit eu ipsum. Mauris ut sapien quis nibh volutpat venenatis. Ut viverra justo varius sapien convallis venenatis vel faucibus urna.
+    </p>
+  </div>
+</Preview>
+
+
+<h2>Basic zero axis</h2>
+<Preview>
+  <div class="w-[125px] h-[20px] inline-block">
+    <Chart
+      {data}
+      x="date"
+      xScale={scaleTime()}
+      y="value"
+      yDomain={[0, null]}
+    >
+      <Svg>
+        <Spline class="stroke-1 stroke-accent-500" />
+      </Svg>
+    </Chart>
+  </div>
+</Preview>
+
+
+<h2>With Tooltip and Highlight</h2>
+
+<Preview>
+  <div class="w-[125px] h-[25px]">
+    <Chart
+      {data}
+      x="date"
+      xScale={scaleTime()}
+      y="value"
+      yDomain={[null, null]}
+      tooltip
+    >
+      <Svg>
+        <Spline class="stroke-1 stroke-accent-500" />
+        <Highlight points lines />
+      </Svg>
+      <Tooltip class="text-xs opacity-75"
+        header={(data) => format(data.date, 'eee, MMM do')} let:data>
+        <TooltipItem label="value" value={data.value}>
+        </TooltipItem>
+      </Tooltip>
+    </Chart>
+  </div>
+</Preview>

--- a/src/routes/docs/examples/Sparkline/+page.ts
+++ b/src/routes/docs/examples/Sparkline/+page.ts
@@ -1,0 +1,9 @@
+import pageSource from './+page.svelte?raw';
+
+export async function load() {
+  return {
+    meta: {
+      pageSource,
+    },
+  };
+}


### PR DESCRIPTION
I made a few sparkline examples. A few things of note:
 - If wanting a chart to be within a paragraph tag, it cannot be a div. So made the containing tag a span
 - For the tooltip example, I had issues changing the position of the tooltip. Looks like this is a known issue, with plans to allow for different positioning options in the future (contained prop)