### PR TITLE
Bars bar component refactoring

### DIFF
--- a/src/lib/components/Bar.svelte
+++ b/src/lib/components/Bar.svelte
@@ -1,0 +1,60 @@
+<script lang="ts">
+  import { getContext } from 'svelte';
+  import type { spring as springStore, tweened as tweenedStore } from 'svelte/motion';
+
+  import { createDimensionGetter } from '$lib/utils/rect';
+  import Rect from './Rect.svelte';
+
+  const {x: xContext, y: yContext, rGet, config } = getContext('LayerCake');
+
+  export let bar: Object;
+
+  /**
+   * Override `x` from context.  Useful for multiple Bar instances
+   */
+   export let x = $xContext;
+
+  /**
+   * Override `y` from context.  Useful for multiple Bar instances
+   */
+  export let y = $yContext;
+
+  export let fill: string | undefined = undefined;
+  export let stroke = 'black';
+  export let strokeWidth = 0;
+  export let radius = 0;
+
+  export let getProps: ((obj: { value: any; item: any; index: number }) => any) | undefined =
+    undefined;
+
+  export let padding = 0;
+  export let groupBy: string | undefined = undefined;
+  export let groupPaddingInner = 0.2;
+  export let groupPaddingOuter = 0;
+
+  export let spring: boolean | Parameters<typeof springStore>[1] = undefined;
+  export let tweened: boolean | Parameters<typeof tweenedStore>[1] = undefined;
+
+  $: getDimensions = createDimensionGetter(getContext('LayerCake'), {
+    x,
+    y,
+    groupBy,
+    padding,
+    groupPadding: {
+      inner: groupPaddingInner,
+      outer: groupPaddingOuter,
+    },
+  });
+</script>
+
+<Rect
+  {fill}
+  {spring}
+  {tweened}
+  {stroke}
+  stroke-width={strokeWidth}
+  rx={radius}
+  {...$getDimensions(bar)}
+  {...$$restProps}
+  on:click
+/>

--- a/src/lib/components/Bar.svelte
+++ b/src/lib/components/Bar.svelte
@@ -35,6 +35,8 @@
   export let spring: boolean | Parameters<typeof springStore>[1] = undefined;
   export let tweened: boolean | Parameters<typeof tweenedStore>[1] = undefined;
 
+  $: if (stroke === null || stroke === undefined) stroke = 'black';
+
   $: getDimensions = createDimensionGetter(getContext('LayerCake'), {
     x,
     y,

--- a/src/lib/components/Bars.svelte
+++ b/src/lib/components/Bars.svelte
@@ -2,29 +2,23 @@
   import { getContext } from 'svelte';
   import type { spring as springStore, tweened as tweenedStore } from 'svelte/motion';
 
-  import Rect from './Rect.svelte';
-  import { createDimensionGetter } from '$lib/utils/rect';
+  import Bar from './Bar.svelte';
 
-  const { data, xScale, x: xContext, y: yContext, rGet, config } = getContext('LayerCake');
+  const { data, rGet, config } = getContext('LayerCake');
 
   /**
    * Override `x` from context.  Useful for multiple Bar instances
    */
-  export let x = $xContext;
-  // Convert x to function
-  $: _x = x ? (typeof x === 'string' ? (d) => d[x] : x) : $xContext;
+  export let x: any = undefined; // TODO: Update Type
 
   /**
    * Override `y` from context.  Useful for multiple Bar instances
    */
-  export let y = $yContext;
-  $: _y = y ? (typeof y === 'string' ? (d) => d[y] : y) : $yContext;
+  export let y: any = undefined; // TODO: Update Type
 
   export let stroke = 'black';
   export let strokeWidth = 0;
   export let radius = 0;
-  export let getKey: (item: any, index: number) => any = (item) =>
-    $xScale.bandwidth ? _x(item) : _y(item);
   export let getProps: ((obj: { value: any; item: any; index: number }) => any) | undefined =
     undefined;
   /** Inset the rect for amount of padding.  Useful with multiple bars (bullet, overlap, etc) */
@@ -39,31 +33,27 @@
   export let groupPaddingInner = 0.2;
   export let groupPaddingOuter = 0;
 
-  $: getDimensions = createDimensionGetter(getContext('LayerCake'), {
-    x,
-    y,
-    groupBy,
-    padding,
-    groupPadding: {
-      inner: groupPaddingInner,
-      outer: groupPaddingOuter,
-    },
-  });
 </script>
 
 <g class="Bars">
-  {#each $data as item, index (getKey(item, index))}
-    <Rect
-      data-id={index}
-      fill={$config.r ? $rGet(item) : null}
-      {stroke}
-      stroke-width={strokeWidth}
-      rx={radius}
-      {spring}
-      {tweened}
-      {...$getDimensions(item)}
-      {...getProps?.({ value: _y(item), item, index })}
-      {...$$restProps}
-    />
-  {/each}
+  <slot name="bars">
+    {#each $data as item, index}
+      <Bar
+        bar={item}
+        {x}
+        {y}
+        fill={$config.r ? $rGet(item) : null}
+        {stroke}
+        {strokeWidth}
+        {radius}
+        {spring}
+        {tweened}
+        {groupBy}
+        {padding}
+        {groupPaddingInner}
+        {groupPaddingOuter}
+        {...$$restProps}
+      />
+    {/each}
+  </slot>
 </g>

--- a/src/lib/components/Highlight.svelte
+++ b/src/lib/components/Highlight.svelte
@@ -41,10 +41,6 @@
   /** Show bar and pass props to Rect */
   export let bar: boolean | ComponentProps<Rect> = false;
 
-  export let stroke = 'black';
-  export let strokeWidth = 0;
-  export let radius = 0;
-
   // TODO: Fix circle points being backwards for stack (see AreaStack)
 
   let _points = [];
@@ -192,6 +188,7 @@
     }
   }
 
+  $: if ($tooltip.data && bar) console.log(bar)
 </script>
 
 {#if $tooltip.data}
@@ -211,9 +208,12 @@
     <slot name="bar" bar={bar}>
       <Bar
         spring
-        {stroke}
-        {strokeWidth}
-        {radius}
+        x={typeof bar === 'object' ? bar.x : null}
+        y={typeof bar === 'object' ? bar.y : null}
+        padding={typeof bar === 'object' ? bar.padding : null}
+        stroke={typeof bar === 'object' ? bar.stroke : null}
+        strokeWidth={typeof bar === 'object' ? bar.strokeWidth : null}
+        radius={typeof bar === 'object' ? bar.radius : null}
         bar={$tooltip.data}
         class={cls(!bar.fill && 'fill-accent-500', typeof bar === 'object' ? bar.class : null)}
         on:click

--- a/src/lib/components/Highlight.svelte
+++ b/src/lib/components/Highlight.svelte
@@ -3,10 +3,10 @@
   import { max, min } from 'd3-array';
   import { cls, notNull } from 'svelte-ux';
 
-  import { createDimensionGetter } from '$lib/utils/rect';
   import { isScaleBand } from '$lib/utils/scales';
   import Circle from './Circle.svelte';
   import Line from './Line.svelte';
+  import Bar from './Bar.svelte';
   import Rect from './Rect.svelte';
   import { tooltipContext } from './TooltipContext.svelte';
 
@@ -41,25 +41,9 @@
   /** Show bar and pass props to Rect */
   export let bar: boolean | ComponentProps<Rect> = false;
 
-  export let padding = 0;
-  export let groupBy: string | undefined = undefined;
-  export let groupPaddingInner = 0.2;
-  export let groupPaddingOuter = 0;
-
   export let stroke = 'black';
   export let strokeWidth = 0;
   export let radius = 0;
-
-  $: getDimensions = createDimensionGetter(getContext('LayerCake'), {
-    $x,
-    $y,
-    groupBy,
-    padding,
-    groupPadding: {
-      inner: groupPaddingInner,
-      outer: groupPaddingOuter,
-    },
-  });
 
   // TODO: Fix circle points being backwards for stack (see AreaStack)
 
@@ -225,13 +209,12 @@
 
   {#if bar}
     <slot name="bar" bar={bar}>
-      <Rect
+      <Bar
         spring
         {stroke}
-        stroke-width={strokeWidth}
-        rx={radius}
-        {...$getDimensions($tooltip.data)}
-        {...typeof bar === 'object' ? bar : null}
+        {strokeWidth}
+        {radius}
+        bar={$tooltip.data}
         class={cls(!bar.fill && 'fill-accent-500', typeof bar === 'object' ? bar.class : null)}
         on:click
       />

--- a/src/lib/components/Highlight.svelte
+++ b/src/lib/components/Highlight.svelte
@@ -187,8 +187,6 @@
       ];
     }
   }
-
-  $: if ($tooltip.data && bar) console.log(bar)
 </script>
 
 {#if $tooltip.data}

--- a/src/lib/components/Highlight.svelte
+++ b/src/lib/components/Highlight.svelte
@@ -3,6 +3,7 @@
   import { max, min } from 'd3-array';
   import { cls, notNull } from 'svelte-ux';
 
+  import { createDimensionGetter } from '$lib/utils/rect';
   import { isScaleBand } from '$lib/utils/scales';
   import Circle from './Circle.svelte';
   import Line from './Line.svelte';
@@ -36,6 +37,29 @@
 
   /** Show area and pass props to Rect */
   export let area: boolean | ComponentProps<Rect> = false;
+
+  /** Show bar and pass props to Rect */
+  export let bar: boolean | ComponentProps<Rect> = false;
+
+  export let padding = 0;
+  export let groupBy: string | undefined = undefined;
+  export let groupPaddingInner = 0.2;
+  export let groupPaddingOuter = 0;
+
+  export let stroke = 'black';
+  export let strokeWidth = 0;
+  export let radius = 0;
+
+  $: getDimensions = createDimensionGetter(getContext('LayerCake'), {
+    $x,
+    $y,
+    groupBy,
+    padding,
+    groupPadding: {
+      inner: groupPaddingInner,
+      outer: groupPaddingOuter,
+    },
+  });
 
   // TODO: Fix circle points being backwards for stack (see AreaStack)
 
@@ -183,6 +207,7 @@
       ];
     }
   }
+
 </script>
 
 {#if $tooltip.data}
@@ -197,6 +222,22 @@
       />
     </slot>
   {/if}
+
+  {#if bar}
+    <slot name="bar" bar={bar}>
+      <Rect
+        spring
+        {stroke}
+        stroke-width={strokeWidth}
+        rx={radius}
+        {...$getDimensions($tooltip.data)}
+        {...typeof bar === 'object' ? bar : null}
+        class={cls(!bar.fill && 'fill-accent-500', typeof bar === 'object' ? bar.class : null)}
+        on:click
+      />
+    </slot>
+  {/if}
+
 
   {#if lines}
     <slot name="lines" lines={_lines}>

--- a/src/routes/_NavMenu.svelte
+++ b/src/routes/_NavMenu.svelte
@@ -16,6 +16,7 @@
       'Line',
       'PunchCard',
       'Scatter',
+      'Sparkbar',
       'Sparkline',
       'Threshold',
     ],

--- a/src/routes/docs/components/Tooltip/+page.svelte
+++ b/src/routes/docs/components/Tooltip/+page.svelte
@@ -430,6 +430,7 @@
           points={charts.bars.highlight.includes('points')}
           lines={charts.bars.highlight.includes('lines')}
           area={charts.bars.highlight.includes('area')}
+          bar={charts.bars.highlight.includes('bar') ? {radius: 4, class: 'fill-accent-800'} : false}
           axis={charts.bars.axis}
         />
       </Svg>
@@ -475,7 +476,11 @@
           points={charts.multiBars.highlight.includes('points')}
           lines={charts.multiBars.highlight.includes('lines')}
           area={charts.multiBars.highlight.includes('area')}
+          bar={charts.multiBars.highlight.includes('bar') ? {y: "baseline", radius: 4, strokeWidth: 1, class: "fill-gray-400"} : false}
           axis={charts.multiBars.axis}
+        />
+        <Highlight
+          bar={charts.multiBars.highlight.includes('bar') ? {y: "value", radius: 4, padding: 16, strokeWidth: 1, class: "fill-accent-800"} : false}
         />
       </Svg>
       <Tooltip header={(data) => format(data.date, 'eee, MMMM do')} let:data>

--- a/src/routes/docs/components/Tooltip/TooltipControls.svelte
+++ b/src/routes/docs/components/Tooltip/TooltipControls.svelte
@@ -40,6 +40,7 @@
       { name: 'points', value: 'points' },
       { name: 'lines', value: 'lines' },
       { name: 'area', value: 'area' },
+      { name: 'bar', value: 'bar' },
     ]}
     formatSelected={({ options }) => options.map((x) => x.name).join(', ')}
   />

--- a/src/routes/docs/examples/Bars/+page.svelte
+++ b/src/routes/docs/examples/Bars/+page.svelte
@@ -143,6 +143,34 @@
   </div>
 </Preview>
 
+<h2>with Tooltip and Bar Highlight</h2>
+
+<Preview>
+  <div class="h-[300px] p-4 border rounded">
+    <Chart
+      {data}
+      x="value"
+      xDomain={[0, null]}
+      xNice
+      y="date"
+      yScale={scaleBand().padding(0.4)}
+      padding={{ left: 16, bottom: 24 }}
+      tooltip={{ mode: 'band' }}
+    >
+      <Svg>
+        <Axis placement="bottom" grid rule />
+        <Axis placement="left" format={(d) => formatDate(d, PeriodType.Day, 'short')} rule />
+        <Bars radius={4} strokeWidth={1} class="fill-gray-300" />
+        <Highlight area bar={{class: "fill-accent-500", strokeWidth: 1, radius: 4}} />
+      </Svg>
+      <Tooltip header={(data) => format(data.date, 'eee, MMMM do')} let:data>
+        <TooltipItem label="value" value={data.value} />
+      </Tooltip>
+    </Chart>
+  </div>
+</Preview>
+
+
 <h2>with Labels and negative data</h2>
 
 <Preview>

--- a/src/routes/docs/examples/Columns/+page.svelte
+++ b/src/routes/docs/examples/Columns/+page.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import { cls } from 'svelte-ux';
   import { cubicInOut } from 'svelte/easing';
   import { scaleBand, scaleOrdinal } from 'd3-scale';
   import { format } from 'date-fns';
@@ -133,7 +134,8 @@
       <Svg>
         <Axis placement="left" grid rule />
         <Axis placement="bottom" format={(d) => formatDate(d, PeriodType.Day, 'short')} rule />
-        <Bars radius={4} strokeWidth={1} class="fill-accent-500" />
+        <Bars radius={4} strokeWidth={1} class="fill-gray-200 stroke-gray-400" />
+        <Highlight radius={4} strokeWidth={1} bar={{class: "fill-accent-500 stroke-gray-400"}} />
         <Highlight area />
       </Svg>
       <Tooltip header={(data) => format(data.date, 'eee, MMMM do')} let:data>

--- a/src/routes/docs/examples/Columns/+page.svelte
+++ b/src/routes/docs/examples/Columns/+page.svelte
@@ -135,7 +135,7 @@
         <Axis placement="left" grid rule />
         <Axis placement="bottom" format={(d) => formatDate(d, PeriodType.Day, 'short')} rule />
         <Bars radius={4} strokeWidth={1} class="fill-gray-200 stroke-gray-400" />
-        <Highlight radius={4} strokeWidth={1} bar={{class: "fill-accent-500 stroke-gray-400"}} />
+        <Highlight bar={{class: "fill-accent-500", stroke: 'black', strokeWidth: 1, radius: 4}} />
         <Highlight area />
       </Svg>
       <Tooltip header={(data) => format(data.date, 'eee, MMMM do')} let:data>
@@ -163,7 +163,7 @@
         <Axis placement="left" grid rule />
         <Axis placement="bottom" format={(d) => formatDate(d, PeriodType.Day, 'short')} rule />
         <Bars radius={4} strokeWidth={1} class="fill-accent-500" />
-        <Highlight bar={{class: "fill-green-400"}} strokeWidth={1} radius={4}  />
+        <Highlight bar={{class: "fill-green-400", strokeWidth: 1, radius: 4}} />
       </Svg>
       <Tooltip header={(data) => format(data.date, 'eee, MMMM do')} let:data>
         <TooltipItem label="value" value={data.value} />

--- a/src/routes/docs/examples/Columns/+page.svelte
+++ b/src/routes/docs/examples/Columns/+page.svelte
@@ -134,8 +134,7 @@
       <Svg>
         <Axis placement="left" grid rule />
         <Axis placement="bottom" format={(d) => formatDate(d, PeriodType.Day, 'short')} rule />
-        <Bars radius={4} strokeWidth={1} class="fill-gray-200 stroke-gray-400" />
-        <Highlight bar={{class: "fill-accent-500", stroke: 'black', strokeWidth: 1, radius: 4}} />
+        <Bars radius={4} strokeWidth={1} class="fill-accent-500" />
         <Highlight area />
       </Svg>
       <Tooltip header={(data) => format(data.date, 'eee, MMMM do')} let:data>
@@ -145,7 +144,7 @@
   </div>
 </Preview>
 
-<h2>with Tooltip and Bar only Highlight</h2>
+<h2>with Tooltip and Bar Highlight</h2>
 
 <Preview>
   <div class="h-[300px] p-4 border rounded">
@@ -162,8 +161,8 @@
       <Svg>
         <Axis placement="left" grid rule />
         <Axis placement="bottom" format={(d) => formatDate(d, PeriodType.Day, 'short')} rule />
-        <Bars radius={4} strokeWidth={1} class="fill-accent-500" />
-        <Highlight bar={{class: "fill-green-400", strokeWidth: 1, radius: 4}} />
+        <Bars radius={4} strokeWidth={1} class="fill-gray-300" />
+        <Highlight area bar={{class: "fill-accent-500", strokeWidth: 1, radius: 4}} />
       </Svg>
       <Tooltip header={(data) => format(data.date, 'eee, MMMM do')} let:data>
         <TooltipItem label="value" value={data.value} />

--- a/src/routes/docs/examples/Columns/+page.svelte
+++ b/src/routes/docs/examples/Columns/+page.svelte
@@ -143,6 +143,33 @@
   </div>
 </Preview>
 
+<h2>with Tooltip and Bar only Highlight</h2>
+
+<Preview>
+  <div class="h-[300px] p-4 border rounded">
+    <Chart
+      {data}
+      x="date"
+      xScale={scaleBand().padding(0.4)}
+      y="value"
+      yDomain={[0, null]}
+      yNice
+      padding={{ left: 16, bottom: 24 }}
+      tooltip={{ mode: 'band' }}
+    >
+      <Svg>
+        <Axis placement="left" grid rule />
+        <Axis placement="bottom" format={(d) => formatDate(d, PeriodType.Day, 'short')} rule />
+        <Bars radius={4} strokeWidth={1} class="fill-accent-500" />
+        <Highlight bar={{class: "fill-green-400"}} strokeWidth={1} radius={4}  />
+      </Svg>
+      <Tooltip header={(data) => format(data.date, 'eee, MMMM do')} let:data>
+        <TooltipItem label="value" value={data.value} />
+      </Tooltip>
+    </Chart>
+  </div>
+</Preview>
+
 <h2>with Labels and negative data</h2>
 
 <Preview>

--- a/src/routes/docs/examples/Columns/+page.ts
+++ b/src/routes/docs/examples/Columns/+page.ts
@@ -4,7 +4,7 @@ export async function load() {
   return {
     meta: {
       pageSource,
-      related: ['components/Bars', 'examples/Bars', 'examples/Histogram'],
+      related: ['components/Bars', 'examples/Bars', 'examples/Histogram', 'examples/Sparkbar'],
     },
   };
 }

--- a/src/routes/docs/examples/Sparkbar/+page.svelte
+++ b/src/routes/docs/examples/Sparkbar/+page.svelte
@@ -96,19 +96,10 @@
       y="value"
       yDomain={[0, null]}
       tooltip
-      let:tooltip
     >
       <Svg>
-        <Bars strokeWidth={1}
-          getProps={(obj) => {
-            return {
-              class: cls(
-                tooltip.data === obj.item ? 'fill-green-500' : 'fill-gray-200',
-                "stroke-gray-400"
-              ),
-            };
-          }}
-        />
+        <Bars strokeWidth={1} class="fill-gray-200 stroke-gray-400" />
+        <Highlight bar={{strokeWidth: 1}} />
       </Svg>
       <Tooltip
         class="text-xs"
@@ -139,7 +130,7 @@
     >
       <Svg>
         <Bars strokeWidth={1} class="fill-gray-200 stroke-gray-400" />
-        <Highlight bar={{class: "fill-accent-500 stroke-gray-600"}} strokeWidth={1} />
+        <Highlight bar={{strokeWidth: 1}} />
       </Svg>
       <Tooltip
         class="text-xs"
@@ -175,7 +166,7 @@
         >
           <Svg>
             <Bars strokeWidth={1} class="fill-gray-200 stroke-gray-400" />
-            <Highlight bar={{class: "fill-accent-500 stroke-gray-600"}} strokeWidth={1} />
+            <Highlight bar={{strokeWidth: 1}} />
           </Svg>
           <Tooltip
             class="text-xs"

--- a/src/routes/docs/examples/Sparkbar/+page.svelte
+++ b/src/routes/docs/examples/Sparkbar/+page.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
   import { scaleBand } from 'd3-scale';
-  import { stackOffsetExpand } from 'd3-shape';
   import { format } from 'date-fns';
 
   import Chart, { Svg } from '$lib/components/Chart.svelte';
@@ -10,8 +9,7 @@
   import TooltipItem from '$lib/components/TooltipItem.svelte';
 
   import Preview from '$lib/docs/Preview.svelte';
-  import { createStackData, stackOffsetSeparated } from '$lib/utils/stack';
-  import { createDateSeries, longData } from '$lib/utils/genData';
+  import { createDateSeries } from '$lib/utils/genData';
 
   const data = createDateSeries({
     count: 30,
@@ -21,60 +19,6 @@
     keys: ['value', 'baseline'],
   });
   const negativeData = createDateSeries({ count: 30, min: -20, max: 50, value: 'integer' });
-
-  const groupedData = createStackData(longData, { xKey: 'year', groupBy: 'fruit' });
-  const stackedData = createStackData(longData, { xKey: 'year', stackBy: 'fruit' });
-  const groupedStackedData = createStackData(longData, {
-    xKey: 'year',
-    groupBy: 'basket',
-    stackBy: 'fruit',
-  });
-  const stackedPercentData = createStackData(longData, {
-    xKey: 'year',
-    stackBy: 'fruit',
-    offset: stackOffsetExpand,
-  });
-  const stackedSeperatedData = createStackData(longData, {
-    xKey: 'year',
-    stackBy: 'fruit',
-    offset: stackOffsetSeparated,
-  });
-
-  const colorKeys = [...new Set(longData.map((x) => x.fruit))];
-  const keyColors = [
-    'var(--color-blue-500)',
-    'var(--color-green-500)',
-    'var(--color-purple-500)',
-    'var(--color-orange-500)',
-  ];
-
-  let transitionChartMode = 'group';
-  $: transitionChart =
-    transitionChartMode === 'group'
-      ? {
-          groupBy: 'fruit',
-          stackBy: undefined,
-        }
-      : transitionChartMode === 'stack'
-      ? {
-          groupBy: undefined,
-          stackBy: 'fruit',
-        }
-      : transitionChartMode === 'groupStack'
-      ? {
-          groupBy: 'basket',
-          stackBy: 'fruit',
-        }
-      : {
-          groupBy: undefined,
-          stackBy: undefined,
-        };
-  $: transitionData = createStackData(longData, {
-    xKey: 'year',
-    groupBy: transitionChart.groupBy,
-    stackBy: transitionChart.stackBy,
-  });
-  // $: console.log({ transitionData })
 </script>
 
 <h1>Examples</h1>
@@ -122,7 +66,6 @@
 </Preview>
 
 
-
 <h2>Basic negative data</h2>
 
 <Preview>
@@ -132,7 +75,6 @@
       x="date"
       xScale={scaleBand()}
       y="value"
-      yDomain={[null, null]}
     >
       <Svg>
         <Bars strokeWidth={1} class="fill-gray-200 stroke-gray-400" />
@@ -143,14 +85,15 @@
 
 
 <h2>With Tooltip and Highlight</h2>
+
 <Preview>
-  <div class="w-[125px] h-[25px]">
+  <div class="w-[125px] h-[18px]">
     <Chart
       {data}
       x="date"
       xScale={scaleBand()}
       y="value"
-      yDomain={[null, null]}
+      yDomain={[0, null]}
       tooltip
     >
       <Svg>
@@ -167,5 +110,76 @@
       </Tooltip>
     </Chart>
 
+  </div>
+</Preview>
+
+
+<h2>With Tooltip and Highlight (fixed position)</h2>
+
+<Preview>
+  <div class="w-[125px] h-[18px]">
+    <Chart
+      {data}
+      x="date"
+      xScale={scaleBand()}
+      y="value"
+      yDomain={[0, null]}
+      tooltip
+      let:containerWidth
+    >
+      <Svg>
+        <Bars strokeWidth={1} class="fill-gray-200 stroke-gray-400" />
+        <Highlight bar={{class: "fill-accent-500 stroke-gray-600"}} strokeWidth={1} />
+      </Svg>
+      <Tooltip
+        class="text-xs"
+        contained={false}
+        header={(data) => format(data.date, 'eee, MMM do')}
+        top={-12}
+        left={containerWidth + 8}
+        let:data
+      >
+        <TooltipItem label="value" value={data.value} />
+      </Tooltip>
+    </Chart>
+
+  </div>
+</Preview>
+
+
+<h2>Basic within a paragraph with Tooltip and Highlight</h2>
+<Preview>
+  <div>
+    <p>
+      Lorem ipsum dolor sit amet, consectetur adipiscing elit. Etiam pretium, ligula ac sollicitudin
+      ullamcorper, leo justo pretium tellus, at gravida ex quam et orci.
+      <span class="w-[125px] h-[18px] inline-block">
+        <Chart
+          {data}
+          x="date"
+          xScale={scaleBand()}
+          y="value"
+          yDomain={[0, null]}
+          tooltip
+          let:containerHeight
+        >
+          <Svg>
+            <Bars strokeWidth={1} class="fill-gray-200 stroke-gray-400" />
+            <Highlight bar={{class: "fill-accent-500 stroke-gray-600"}} strokeWidth={1} />
+          </Svg>
+          <Tooltip
+            class="text-xs"
+            contained={false}
+            header={(data) => format(data.date, 'eee, MMM do')}
+            top={containerHeight + 4}
+            leftOffset={0}
+            let:data
+          >
+            <TooltipItem label="value" value={data.value} />
+          </Tooltip>
+        </Chart>
+      </span> Sed ipsum justo, facilisis id tempor hendrerit, suscipit eu ipsum. Mauris ut sapien quis
+      nibh volutpat venenatis. Ut viverra justo varius sapien convallis venenatis vel faucibus urna.
+    </p>
   </div>
 </Preview>

--- a/src/routes/docs/examples/Sparkbar/+page.svelte
+++ b/src/routes/docs/examples/Sparkbar/+page.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import { scaleBand } from 'd3-scale';
   import { format } from 'date-fns';
+  import { cls } from 'svelte-ux';
 
   import Chart, { Svg } from '$lib/components/Chart.svelte';
   import Bars from '$lib/components/Bars.svelte';
@@ -95,10 +96,19 @@
       y="value"
       yDomain={[0, null]}
       tooltip
+      let:tooltip
     >
       <Svg>
-        <Bars strokeWidth={1} class="fill-gray-200 stroke-gray-400" />
-        <Highlight bar={{class: "fill-accent-500 stroke-gray-600"}} strokeWidth={1} />
+        <Bars strokeWidth={1}
+          getProps={(obj) => {
+            return {
+              class: cls(
+                tooltip.data === obj.item ? 'fill-green-500' : 'fill-gray-200',
+                "stroke-gray-400"
+              ),
+            };
+          }}
+        />
       </Svg>
       <Tooltip
         class="text-xs"

--- a/src/routes/docs/examples/Sparkbar/+page.svelte
+++ b/src/routes/docs/examples/Sparkbar/+page.svelte
@@ -1,0 +1,171 @@
+<script lang="ts">
+  import { scaleBand } from 'd3-scale';
+  import { stackOffsetExpand } from 'd3-shape';
+  import { format } from 'date-fns';
+
+  import Chart, { Svg } from '$lib/components/Chart.svelte';
+  import Bars from '$lib/components/Bars.svelte';
+  import Highlight from '$lib/components/Highlight.svelte';
+  import Tooltip from '$lib/components/Tooltip.svelte';
+  import TooltipItem from '$lib/components/TooltipItem.svelte';
+
+  import Preview from '$lib/docs/Preview.svelte';
+  import { createStackData, stackOffsetSeparated } from '$lib/utils/stack';
+  import { createDateSeries, longData } from '$lib/utils/genData';
+
+  const data = createDateSeries({
+    count: 30,
+    min: 20,
+    max: 100,
+    value: 'integer',
+    keys: ['value', 'baseline'],
+  });
+  const negativeData = createDateSeries({ count: 30, min: -20, max: 50, value: 'integer' });
+
+  const groupedData = createStackData(longData, { xKey: 'year', groupBy: 'fruit' });
+  const stackedData = createStackData(longData, { xKey: 'year', stackBy: 'fruit' });
+  const groupedStackedData = createStackData(longData, {
+    xKey: 'year',
+    groupBy: 'basket',
+    stackBy: 'fruit',
+  });
+  const stackedPercentData = createStackData(longData, {
+    xKey: 'year',
+    stackBy: 'fruit',
+    offset: stackOffsetExpand,
+  });
+  const stackedSeperatedData = createStackData(longData, {
+    xKey: 'year',
+    stackBy: 'fruit',
+    offset: stackOffsetSeparated,
+  });
+
+  const colorKeys = [...new Set(longData.map((x) => x.fruit))];
+  const keyColors = [
+    'var(--color-blue-500)',
+    'var(--color-green-500)',
+    'var(--color-purple-500)',
+    'var(--color-orange-500)',
+  ];
+
+  let transitionChartMode = 'group';
+  $: transitionChart =
+    transitionChartMode === 'group'
+      ? {
+          groupBy: 'fruit',
+          stackBy: undefined,
+        }
+      : transitionChartMode === 'stack'
+      ? {
+          groupBy: undefined,
+          stackBy: 'fruit',
+        }
+      : transitionChartMode === 'groupStack'
+      ? {
+          groupBy: 'basket',
+          stackBy: 'fruit',
+        }
+      : {
+          groupBy: undefined,
+          stackBy: undefined,
+        };
+  $: transitionData = createStackData(longData, {
+    xKey: 'year',
+    groupBy: transitionChart.groupBy,
+    stackBy: transitionChart.stackBy,
+  });
+  // $: console.log({ transitionData })
+</script>
+
+<h1>Examples</h1>
+
+<h2>Basic</h2>
+
+<Preview>
+  <div class="w-[125px] h-[18px]">
+    <Chart
+      {data}
+      x="date"
+      xScale={scaleBand()}
+      y="value"
+      yDomain={[0, null]}
+    >
+      <Svg>
+        <Bars strokeWidth={1} class="fill-gray-200 stroke-gray-400" />
+      </Svg>
+    </Chart>
+  </div>
+</Preview>
+
+<h2>Basic within a paragraph</h2>
+<Preview>
+  <div>
+    <p>
+      Lorem ipsum dolor sit amet, consectetur adipiscing elit. Etiam pretium, ligula ac sollicitudin
+      ullamcorper, leo justo pretium tellus, at gravida ex quam et orci.
+      <span class="w-[125px] h-[18px] inline-block">
+        <Chart
+          {data}
+          x="date"
+          xScale={scaleBand()}
+          y="value"
+          yDomain={[0, null]}
+        >
+          <Svg>
+            <Bars strokeWidth={1} class="fill-gray-200 stroke-gray-400" />
+          </Svg>
+        </Chart>
+      </span> Sed ipsum justo, facilisis id tempor hendrerit, suscipit eu ipsum. Mauris ut sapien quis
+      nibh volutpat venenatis. Ut viverra justo varius sapien convallis venenatis vel faucibus urna.
+    </p>
+  </div>
+</Preview>
+
+
+
+<h2>Basic negative data</h2>
+
+<Preview>
+  <div class="w-[125px] h-[18px]">
+    <Chart
+      data={negativeData}
+      x="date"
+      xScale={scaleBand()}
+      y="value"
+      yDomain={[null, null]}
+    >
+      <Svg>
+        <Bars strokeWidth={1} class="fill-gray-200 stroke-gray-400" />
+      </Svg>
+    </Chart>
+  </div>
+</Preview>
+
+
+<h2>With Tooltip and Highlight</h2>
+<Preview>
+  <div class="w-[125px] h-[25px]">
+    <Chart
+      {data}
+      x="date"
+      xScale={scaleBand()}
+      y="value"
+      yDomain={[null, null]}
+      tooltip
+    >
+      <Svg>
+        <Bars strokeWidth={1} class="fill-gray-200 stroke-gray-400" />
+        <Highlight bar={{class: "fill-accent-500 stroke-gray-600"}} strokeWidth={1} />
+      </Svg>
+      <Tooltip
+        class="text-xs"
+        contained={false}
+        header={(data) => format(data.date, 'eee, MMM do')}
+        let:data
+      >
+        <TooltipItem label="value" value={data.value} />
+      </Tooltip>
+    </Chart>
+
+  </div>
+</Preview>

--- a/src/routes/docs/examples/Sparkbar/+page.ts
+++ b/src/routes/docs/examples/Sparkbar/+page.ts
@@ -4,7 +4,7 @@ export async function load() {
   return {
     meta: {
       pageSource,
-      related: ['components/Bars', 'examples/Columns', 'examples/Histogram'],
+      related: ['components/Bars', 'examples/Columns', 'examples/Histogram', 'examples/Sparkline'],
     },
   };
 }

--- a/src/routes/docs/examples/Sparkbar/+page.ts
+++ b/src/routes/docs/examples/Sparkbar/+page.ts
@@ -4,7 +4,7 @@ export async function load() {
   return {
     meta: {
       pageSource,
-      related: ['components/Bars', 'examples/Bars', 'examples/Histogram'],
+      related: ['components/Bars', 'examples/Columns', 'examples/Histogram'],
     },
   };
 }

--- a/src/routes/docs/examples/Sparkbar/+page.ts
+++ b/src/routes/docs/examples/Sparkbar/+page.ts
@@ -1,0 +1,10 @@
+import pageSource from './+page.svelte?raw';
+
+export async function load() {
+  return {
+    meta: {
+      pageSource,
+      related: ['components/Bars', 'examples/Bars', 'examples/Histogram'],
+    },
+  };
+}

--- a/src/routes/docs/examples/Sparkline/+page.ts
+++ b/src/routes/docs/examples/Sparkline/+page.ts
@@ -4,7 +4,7 @@ export async function load() {
   return {
     meta: {
       pageSource,
-      related: ['components/Spline', 'components/Tooltip', 'components/Highlight'],
+      related: ['components/Spline', 'components/Tooltip', 'components/Highlight', 'examples/Sparkbar'],
     },
   };
 }


### PR DESCRIPTION
This replaces the previous PR #45.

The goal was refactoring Bars.svelte to better handle bar highlights.

I went with keeping the two different props (bar and area) for the Highlight component. This made more sense to me when dealing with examples like the multi-bar example for the Tooltip component.

I was not able to use setContext and getContext because Highlight is a sibling of Bars, not a child. I initially thought it would get the context from the closest sibling, but that is not the case. Therefore if you choose to have non-default values for thins like stroke, radius, and strokeWidth need to be passed in with the bar prop.

Open to feedback on improving this PR.

