### PR TITLE
Fix #85: tooltip slot prop type error

### DIFF
--- a/packages/layerchart/src/lib/components/Chart.svelte
+++ b/packages/layerchart/src/lib/components/Chart.svelte
@@ -137,6 +137,7 @@
         {width}
         {element}
         {projection}
+        {tooltip}
         {xScale}
         {yScale}
         {zScale}
@@ -144,7 +145,7 @@
         {padding}
         {data}
         {flatData}
-      />
+        />
     {/if}
   </GeoContext>
 </LayerCake>


### PR DESCRIPTION
Passing the same properties indecently of tooltip presence will make it correctly infer types.