### PR TITLE
docs: import from layerchart using alias

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ pnpm i
 ### Run dev server for `layerchart` package
 
 ```
-cd packages/svelte-ux
+cd packages/layerchart
 pnpm dev
 ```
 

--- a/packages/layerchart/src/routes/docs/components/Arc/+page.svelte
+++ b/packages/layerchart/src/routes/docs/components/Arc/+page.svelte
@@ -1,11 +1,7 @@
 <script lang="ts">
   import { Field, RangeField, Switch } from 'svelte-ux';
 
-  import Chart, { Svg } from '$lib/components/Chart.svelte';
-  import Arc from '$lib/components/Arc.svelte';
-  import Group from '$lib/components/Group.svelte';
-  import LinearGradient from '$lib/components/LinearGradient.svelte';
-  import Text from '$lib/components/Text.svelte';
+  import { Arc, Chart, Svg, Group, LinearGradient, Text } from 'layerchart';
 
   import Preview from '$lib/docs/Preview.svelte';
 

--- a/packages/layerchart/src/routes/getting-started/+page.svelte
+++ b/packages/layerchart/src/routes/getting-started/+page.svelte
@@ -123,25 +123,7 @@
     libraries (i.e.<code>{'<script>'}</code>
     block). You can view the full page source by clicking on <strong>Page source</strong> at the top
     of each examples page. This will show you all of the imports used for that page.
-    <Blockquote>
-      <div>
-        <strong>Note:</strong> This site is built directly from LayerChart's codebase and does not
-        <code>npm install layerchart</code>. Therefore it imports components from LayerChart
-        differently.
-      </div>
-    </Blockquote>
   </p>
-
-  <p>The page source will show:</p>
-  <Code
-    source={`import Chart, { Svg } from '$lib/components/Chart.svelte';
-import Axis from '$lib/components/Axis.svelte';
-import Bars from '$lib/components/Bars.svelte';`}
-    language="js"
-  />
-
-  <p>If you followed instructions to `npm install layerchart` your code should be:</p>
-  <Code source={`import { Chart, Svg, Axis, Bars } from 'layerchart';`} language="js" />
 
   <h2>Layer Cake</h2>
 

--- a/packages/layerchart/svelte.config.js
+++ b/packages/layerchart/svelte.config.js
@@ -12,6 +12,10 @@ const config = {
 
   kit: {
     adapter: adapter(),
+    alias: {
+      'layerchart': 'src/lib/index.js',
+			'layerchart/*': 'src/lib/*'
+    }
   },
 };
 


### PR DESCRIPTION
Sean, awesome talk! Noticed you were using different imports for your docs than users need to use. I have the same situation in Kitbook and using an alias solves it. So then you can import from `layerchart` which just happens to be an alias to your lib directory. In mine I do `'kitbook': 'src/lib'` but in yours I had to do `'layerchart': 'src/lib/index.js'`. I'm not sure why, but it works. Anyhow you can see how I changed your Arc docs to utilize it. If you like it, you can spread it across the rest of your examples. :)

And yes, let's talk more if you ever decide to use Kitbook. There's a some glaring features missing from it like view source code which would be almost trivial to add as I have the raw strings from each component already, I just haven't taken the time to do it. 1 thing at a time you know. But it sure would make it easier for you in some spots like how you're writing your getting started page in html, not markdown.

Oh, and Kitbook has no dark mode support or any theme for that matter and you've blown it out of the water. So that's another thing you might want to see in Kitbook first. Not sure what's important to you.