### PR TITLE
Integrated TransformContext

### DIFF
--- a/.changeset/bright-carrots-boil.md
+++ b/.changeset/bright-carrots-boil.md
@@ -1,0 +1,5 @@
+---
+'layerchart': minor
+---
+
+Integrate `Transform` into `Chart` (<Chart transform={...} let:transform>) and expose as `transformContext()`. Renamed to `TransformContext` and removed direct SVG control (now handled by `Svg` and `Canvas` components)

--- a/.changeset/green-frogs-drop.md
+++ b/.changeset/green-frogs-drop.md
@@ -1,0 +1,5 @@
+---
+"layerchart": patch
+---
+
+[TransformControls] Use transformContext instead of `transformn` prop

--- a/.changeset/green-frogs-drop.md
+++ b/.changeset/green-frogs-drop.md
@@ -1,5 +1,5 @@
 ---
-"layerchart": patch
+'layerchart': patch
 ---
 
-[TransformControls] Use transformContext instead of `transformn` prop
+[TransformControls] Use transformContext instead of `transform` prop

--- a/.changeset/honest-lemons-bake.md
+++ b/.changeset/honest-lemons-bake.md
@@ -1,5 +1,5 @@
 ---
-"layerchart": minor
+'layerchart': minor
 ---
 
-Support tranform with Canvas layers (geo, etc)
+Support transform with Canvas layers (ex. geo, etc)

--- a/.changeset/honest-lemons-bake.md
+++ b/.changeset/honest-lemons-bake.md
@@ -1,0 +1,5 @@
+---
+"layerchart": minor
+---
+
+Support tranform with Canvas layers (geo, etc)

--- a/.changeset/soft-owls-cheat.md
+++ b/.changeset/soft-owls-cheat.md
@@ -1,0 +1,5 @@
+---
+"layerchart": patch
+---
+
+[GeoContext] Integrate with new TransformContext

--- a/.changeset/sour-planes-boil.md
+++ b/.changeset/sour-planes-boil.md
@@ -1,0 +1,5 @@
+---
+'layerchart': patch
+---
+
+[GeoPath] Respect `strokeWidth` prop within Svg context (not just `stroke-width` attribute) to align with Canvas context usage

--- a/.changeset/twenty-chefs-tickle.md
+++ b/.changeset/twenty-chefs-tickle.md
@@ -1,0 +1,5 @@
+---
+"layerchart": minor
+---
+
+Add new Canvas component (derived from LayerCake) which handles `scaleCanvas()` globally and supports scale/translate transforms

--- a/packages/layerchart/src/lib/components/Chart.svelte
+++ b/packages/layerchart/src/lib/components/Chart.svelte
@@ -8,9 +8,10 @@
     LayerCake,
     Svg as _Svg,
     Html as _Html,
-    Canvas as _Canvas,
+    // Canvas as _Canvas,
     WebGL as _WebGL,
   } from 'layercake';
+  import _Canvas from './layout/Canvas.svelte';
 
   export const Svg = _Svg;
   export const Html = _Html;

--- a/packages/layerchart/src/lib/components/Chart.svelte
+++ b/packages/layerchart/src/lib/components/Chart.svelte
@@ -6,16 +6,17 @@
   // See: https://github.com/carbon-design-system/sveld/issues/104
   import {
     LayerCake,
-    Svg as _Svg,
-    Html as _Html,
     // Canvas as _Canvas,
+    Html as _Html,
+    // Svg as _Svg,
     WebGL as _WebGL,
   } from 'layercake';
   import _Canvas from './layout/Canvas.svelte';
+  import _Svg from './layout/Svg.svelte';
 
-  export const Svg = _Svg;
-  export const Html = _Html;
   export const Canvas = _Canvas;
+  export const Html = _Html;
+  export const Svg = _Svg;
   export const WebGL = _WebGL;
 </script>
 
@@ -24,8 +25,10 @@
   import { max, min } from 'd3-array';
   import { get } from 'lodash-es';
   import { isScaleBand } from '$lib/utils/scales.js';
-  import TooltipContext from './TooltipContext.svelte';
+
   import GeoContext from './GeoContext.svelte';
+  import TooltipContext from './TooltipContext.svelte';
+  import TransformContext from './TransformContext.svelte';
 
   type Accessor = string | ((d: any) => number);
 
@@ -79,9 +82,15 @@
    */
   $: yReverse = yScale ? !isScaleBand(yScale) : true;
 
+  /** Props passed to GeoContext */
+  export let geo: Partial<ComponentProps<GeoContext>> | undefined = undefined;
+
+  /** Props passed to TooltipContext */
   export let tooltip: Partial<ComponentProps<TooltipContext>> | boolean | undefined = undefined;
 
-  export let geo: Partial<ComponentProps<GeoContext>> | undefined = undefined;
+  /** Props passed to TransformContext */
+  export let transform: Partial<ComponentProps<TransformContext>> | undefined = undefined;
+  export let transformContext: TransformContext = undefined;
 </script>
 
 <LayerCake
@@ -111,30 +120,40 @@
   let:data
   let:flatData
 >
-  <GeoContext {...geo} let:projection>
-    {@const tooltipProps = typeof tooltip === 'object' ? tooltip : {}}
-    <TooltipContext {...tooltipProps} let:tooltip>
-      <slot
-        {aspectRatio}
-        {containerHeight}
-        {containerWidth}
-        {height}
-        {width}
-        {element}
-        {projection}
-        {tooltip}
-        {xScale}
-        {xGet}
-        {yScale}
-        {yGet}
-        {zScale}
-        {zGet}
-        {rScale}
-        {rGet}
-        {padding}
-        {data}
-        {flatData}
-      />
-    </TooltipContext>
-  </GeoContext>
+  <TransformContext
+    bind:this={transformContext}
+    {...transform}
+    let:transform={_transform}
+    on:transform
+    on:dragstart
+    on:dragend
+  >
+    <GeoContext {...geo} let:projection>
+      {@const tooltipProps = typeof tooltip === 'object' ? tooltip : {}}
+      <TooltipContext {...tooltipProps} let:tooltip>
+        <slot
+          {aspectRatio}
+          {containerHeight}
+          {containerWidth}
+          {height}
+          {width}
+          {element}
+          {projection}
+          transform={_transform}
+          {tooltip}
+          {xScale}
+          {xGet}
+          {yScale}
+          {yGet}
+          {zScale}
+          {zGet}
+          {rScale}
+          {rGet}
+          {padding}
+          {data}
+          {flatData}
+        />
+      </TooltipContext>
+    </GeoContext>
+  </TransformContext>
 </LayerCake>

--- a/packages/layerchart/src/lib/components/Chart.svelte
+++ b/packages/layerchart/src/lib/components/Chart.svelte
@@ -124,21 +124,26 @@
 >
   <TransformContext
     bind:this={transformContext}
-    processTranslate={(x, y, deltaX, deltaY) => {
-      if (geo?.applyTransform?.includes('rotate')) {
-        // When applying transform to rotate, it works best to invert `y` values and reduce sensitivity based on projection scale
-        // see: https://observablehq.com/@benoldenburg/simple-globe and https://observablehq.com/@michael-keith/draggable-globe-in-d3
-        const projectionScale = $geoProjection.scale();
-        const sensitivity = 75;
-        return {
-          x: x + deltaX * (sensitivity / projectionScale),
-          y: y + deltaY * (sensitivity / projectionScale) * -1,
-        };
-      } else {
-        // translate/etc should use pointer values as is
-        return { x: x + deltaX, y: y + deltaY };
-      }
-    }}
+    processTranslate={geo
+      ? (x, y, deltaX, deltaY, scale) => {
+          if (geo.applyTransform?.includes('rotate')) {
+            // When applying transform to rotate, invert `y` values and reduce sensitivity based on projection scale
+            // see: https://observablehq.com/@benoldenburg/simple-globe and https://observablehq.com/@michael-keith/draggable-globe-in-d3
+            const projectionScale = $geoProjection.scale();
+            const sensitivity = 75;
+            return {
+              x: x + deltaX * (sensitivity / projectionScale),
+              y: y + deltaY * (sensitivity / projectionScale) * -1,
+            };
+          } else if (geo.applyTransform?.includes('translate')) {
+            // When applying to `translate`, use pointer values as is (with no `scale` adjustment)
+            return { x: x + deltaX, y: y + deltaY };
+          } else {
+            // Apply default TransformContext.processTransform (passing `undefined` below appears to not work when checking for `geo?.applyTransform` exists)
+            return { x: x + deltaX / scale, y: y + deltaY / scale };
+          }
+        }
+      : undefined}
     {...transform}
     let:transform={_transform}
     on:transform

--- a/packages/layerchart/src/lib/components/GeoContext.svelte
+++ b/packages/layerchart/src/lib/components/GeoContext.svelte
@@ -49,6 +49,7 @@
   export let translate: [number, number] | undefined = undefined;
   export let center: [number, number] | undefined = undefined;
 
+  /** Apply TransformContext to the selected properties.  Typically `translate` or `rotate` are mutually selected  */
   export let applyTransform: ('scale' | 'translate' | 'rotate')[] = [];
 
   export let reflectX: boolean | undefined = undefined;

--- a/packages/layerchart/src/lib/components/GeoContext.svelte
+++ b/packages/layerchart/src/lib/components/GeoContext.svelte
@@ -7,6 +7,8 @@
     type GeoProjection,
   } from 'd3-geo';
 
+  import { transformContext } from './TransformContext.svelte';
+
   export const geoContextKey = Symbol();
 
   export type GeoContext = Writable<GeoProjection | GeoIdentityTransform>;
@@ -47,11 +49,15 @@
   export let translate: [number, number] | undefined = undefined;
   export let center: [number, number] | undefined = undefined;
 
+  export let applyTransform: ('scale' | 'translate' | 'rotate')[] = [];
+
   export let reflectX: boolean | undefined = undefined;
   export let reflectY: boolean | undefined = undefined;
 
   const geo = writable(projection?.());
   setGeoContext(geo);
+
+  const { scale: transformScale, translate: transformTranslate } = transformContext();
 
   $: fitSizeRange = (fixedAspectRatio ? [100, 100 / fixedAspectRatio] : [$width, $height]) as [
     number,
@@ -65,16 +71,47 @@
       _projection.fitSize(fitSizeRange, fitGeojson);
     }
 
-    if (scale && 'scale' in _projection) {
-      _projection.scale(scale);
+    if ('scale' in _projection) {
+      if (scale) {
+        _projection.scale(scale);
+      }
+
+      if (applyTransform.includes('scale')) {
+        _projection.scale($transformScale);
+      }
     }
 
-    if (rotate && 'rotate' in _projection) {
-      _projection.rotate([rotate.yaw, rotate.pitch, rotate.roll]);
+    if ('rotate' in _projection) {
+      if (rotate) {
+        _projection.rotate([rotate.yaw, rotate.pitch, rotate.roll]);
+      }
+
+      if (applyTransform.includes('rotate')) {
+        // TODO: Works for dragging
+        const sensitivity = 75;
+        _projection.rotate([
+          $transformTranslate.x * (sensitivity / _projection.scale()), // yaw
+          -$transformTranslate.y * (sensitivity / _projection.scale()), // pitch
+          // TODO: `roll` from `transformContext`?
+        ]);
+
+        // TODO: Works for geoCentroid() (AnimateGlobe clicking)
+        // _projection.rotate([
+        //   $transformTranslate.x, // yaw
+        //   $transformTranslate.y, // pitch
+        //   // rotate?.roll,
+        // ]);
+      }
     }
 
-    if (translate && 'translate' in _projection) {
-      _projection.translate(translate);
+    if ('translate' in _projection) {
+      if (translate) {
+        _projection.translate(translate);
+      }
+
+      if (applyTransform.includes('translate')) {
+        _projection.translate([$transformTranslate.x, $transformTranslate.y]);
+      }
     }
 
     if (center && 'center' in _projection) {

--- a/packages/layerchart/src/lib/components/GeoContext.svelte
+++ b/packages/layerchart/src/lib/components/GeoContext.svelte
@@ -55,7 +55,8 @@
   export let reflectX: boolean | undefined = undefined;
   export let reflectY: boolean | undefined = undefined;
 
-  const geo = writable(projection?.());
+  /** Exposed to allow binding in Chart */
+  export let geo = writable(projection?.());
   setGeoContext(geo);
 
   const { scale: transformScale, translate: transformTranslate } = transformContext();
@@ -88,20 +89,11 @@
       }
 
       if (applyTransform.includes('rotate')) {
-        // TODO: Works for dragging
-        const sensitivity = 75;
         _projection.rotate([
-          $transformTranslate.x * (sensitivity / _projection.scale()), // yaw
-          -$transformTranslate.y * (sensitivity / _projection.scale()), // pitch
+          $transformTranslate.x, // yaw
+          $transformTranslate.y, // pitch
           // TODO: `roll` from `transformContext`?
         ]);
-
-        // TODO: Works for geoCentroid() (AnimateGlobe clicking)
-        // _projection.rotate([
-        //   $transformTranslate.x, // yaw
-        //   $transformTranslate.y, // pitch
-        //   // rotate?.roll,
-        // ]);
       }
     }
 

--- a/packages/layerchart/src/lib/components/GeoPath.svelte
+++ b/packages/layerchart/src/lib/components/GeoPath.svelte
@@ -1,7 +1,6 @@
 <script lang="ts">
   import { createEventDispatcher, getContext } from 'svelte';
   import { type GeoPath, type GeoPermissibleObjects } from 'd3-geo';
-  import { scaleCanvas } from 'layercake';
   import { cls } from 'svelte-ux';
 
   import { geoContext } from './GeoContext.svelte';
@@ -58,7 +57,6 @@
     }
 
     // console.count('render');
-    scaleCanvas($ctx, $width, $height);
     $ctx.clearRect(0, 0, $width, $height);
 
     if (render) {

--- a/packages/layerchart/src/lib/components/GeoPath.svelte
+++ b/packages/layerchart/src/lib/components/GeoPath.svelte
@@ -89,6 +89,7 @@
       d={geoPath(geojson)}
       {fill}
       {stroke}
+      stroke-width={strokeWidth}
       on:pointerenter={(e) => tooltip?.show(e, geojson)}
       on:pointerenter
       on:pointermove={(e) => tooltip?.show(e, geojson)}

--- a/packages/layerchart/src/lib/components/GeoPoint.svelte
+++ b/packages/layerchart/src/lib/components/GeoPoint.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
   import { getContext } from 'svelte';
-  import { scaleCanvas } from 'layercake';
 
   import { geoContext } from './GeoContext.svelte';
   import Circle from './Circle.svelte';
@@ -27,8 +26,7 @@
 
   $: ctx = canvas?.ctx;
   $: if (renderContext === 'canvas' && $ctx) {
-    scaleCanvas($ctx, $width, $height);
-    $ctx.clearRect(0, 0, $width, $height);
+    // $ctx.clearRect(0, 0, $width, $height);
 
     // Transfer classes defined on <GeoPoint> to <canvas> to enable window.getComputedStyle() retrieval (Tailwind classes, etc)
     if ($$props.class) {

--- a/packages/layerchart/src/lib/components/GeoTile.svelte
+++ b/packages/layerchart/src/lib/components/GeoTile.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
   import { getContext } from 'svelte';
-  import { scaleCanvas } from 'layercake';
   import { tile as d3Tile } from 'd3-tile';
 
   import { geoContext } from './GeoContext.svelte';
@@ -34,8 +33,7 @@
   $: ctx = canvas?.ctx;
   $: if (renderContext === 'canvas' && $ctx && url) {
     // console.count('render');
-    scaleCanvas($ctx, $width, $height);
-    $ctx.clearRect(0, 0, $width, $height);
+    // $ctx.clearRect(0, 0, $width, $height);
 
     tiles.forEach(([x, y, z]) => {
       const image = new Image();

--- a/packages/layerchart/src/lib/components/HitCanvas.svelte
+++ b/packages/layerchart/src/lib/components/HitCanvas.svelte
@@ -3,10 +3,10 @@
   import { writable } from 'svelte/store';
   import { scaleCanvas } from 'layercake';
   import { cls } from 'svelte-ux';
+  import Canvas from './layout/Canvas.svelte';
 
-  const { width, height, padding } = getContext('LayerCake');
+  const { width, height } = getContext('LayerCake');
 
-  export let element: HTMLCanvasElement = undefined;
   export let context: CanvasRenderingContext2D = undefined;
 
   /** Show canvas for debugging */
@@ -29,7 +29,6 @@
 
   onMount(() => {
     // https://developer.mozilla.org/en-US/docs/Web/API/HTMLCanvasElement/getContext#willreadfrequently
-    context = element.getContext('2d', { willReadFrequently: true });
     scaleCanvas(context, $width, $height);
   });
 
@@ -89,12 +88,9 @@
   }
 </script>
 
-<canvas
-  bind:this={element}
-  style:top="{$padding.top}px"
-  style:bottom="{$padding.bottom}px"
-  style:left="{$padding.left}px"
-  style:right="{$padding.right}px"
+<Canvas
+  bind:context
+  willReadFrequently
   class={cls(
     'HitCanvas absolute w-full h-full border border-danger',
     // '[image-rendering:pixelated]', // https://developer.mozilla.org/en-US/docs/Web/CSS/image-rendering
@@ -117,5 +113,4 @@
     }
   }}
 />
-
-<slot {element} {context} nextColor={() => colorGenerator.next().value} {setColorData}></slot>
+<slot nextColor={() => colorGenerator.next().value} {setColorData}></slot>

--- a/packages/layerchart/src/lib/components/TransformContext.svelte
+++ b/packages/layerchart/src/lib/components/TransformContext.svelte
@@ -5,7 +5,7 @@
   export const transformContextKey = Symbol();
 
   export type TransformContextValue = {
-    mode: 'canvas' | 'manual' | 'none';
+    mode: 'canvas' | 'none';
     scale: Writable<number>;
     translate: Writable<{ x: number; y: number }>;
     dragging: Readable<boolean>;
@@ -45,15 +45,21 @@
 
   const { width, height } = getContext('LayerCake');
 
-  export let mode: 'canvas' | 'manual' | 'none' = 'none';
+  export let mode: 'canvas' | 'none' = 'none';
   export let translateOnScale = false;
   export let spring: boolean | Parameters<typeof motionStore>[1]['spring'] = undefined;
   export let tweened: boolean | Parameters<typeof motionStore>[1]['tweened'] = undefined;
 
-  export let processTranslate = (x: number, y: number, deltaX: number, deltaY: number) => {
+  export let processTranslate = (
+    x: number,
+    y: number,
+    deltaX: number,
+    deltaY: number,
+    scale: number
+  ) => {
     return {
-      x: x + deltaX / (mode === 'manual' ? 1 : $scale),
-      y: y + deltaY / (mode === 'manual' ? 1 : $scale),
+      x: x + deltaX / scale,
+      y: y + deltaY / scale,
     };
   };
 
@@ -164,7 +170,7 @@
       e.currentTarget.setPointerCapture(e.pointerId);
 
       translate.set(
-        processTranslate(startTranslate.x, startTranslate.y, deltaX, deltaY),
+        processTranslate(startTranslate.x, startTranslate.y, deltaX, deltaY, $scale),
         spring ? { hard: true } : tweened ? { duration: 0 } : undefined
       );
     }
@@ -211,7 +217,7 @@
     } else if (scroll === 'translate') {
       translate.update(
         (startTranslate) =>
-          processTranslate(startTranslate.x, startTranslate.y, -e.deltaX, -e.deltaY),
+          processTranslate(startTranslate.x, startTranslate.y, -e.deltaX, -e.deltaY, $scale),
         spring ? { hard: true } : tweened ? { duration: 0 } : undefined
       );
     }

--- a/packages/layerchart/src/lib/components/TransformContext.svelte
+++ b/packages/layerchart/src/lib/components/TransformContext.svelte
@@ -74,7 +74,6 @@
 
   let startPoint: { x: number; y: number } = { x: 0, y: 0 };
   let startTranslate: { x: number; y: number } = { x: 0, y: 0 };
-  let svgEl: SVGSVGElement | null = null;
 
   export function reset() {
     $translate = initialTranslate;
@@ -130,8 +129,7 @@
 
     dragging = true;
     moved = false;
-    svgEl = e.currentTarget.ownerSVGElement; // capture for reference in pointermove event
-    startPoint = localPoint(svgEl, e);
+    startPoint = localPoint(e);
     startTranslate = $translate;
 
     dispatch('dragstart');
@@ -144,7 +142,7 @@
     e.stopPropagation(); // Stop tooltip from trigging (along with `capture: true`)
     e.currentTarget.setPointerCapture(e.pointerId);
 
-    const endPoint = localPoint(svgEl, e);
+    const endPoint = localPoint(e);
     const deltaX = endPoint.x - startPoint.x;
     const deltaY = endPoint.y - startPoint.y;
 
@@ -176,7 +174,7 @@
 
   function onDoubleClick(e) {
     if (disablePointer) return;
-    const point = localPoint(svgEl, e);
+    const point = localPoint(e);
     scaleTo(e.shiftKey ? 0.5 : 2, point);
   }
 
@@ -185,8 +183,7 @@
 
     e.preventDefault();
 
-    svgEl = e.currentTarget.ownerSVGElement;
-    const point = (startPoint = localPoint(svgEl, e));
+    const point = (startPoint = localPoint(e));
 
     // Pinch to zoom is registered as a wheel event with control key
     const pinchToZoom = e.ctrlKey;
@@ -238,25 +235,11 @@
     }
   }
 
-  function localPoint(svgEl: SVGSVGElement | null, e: PointerEvent) {
-    if (svgEl) {
-      const screenCTM = svgEl.getScreenCTM();
-
-      let point = svgEl.createSVGPoint();
-      point.x = e.clientX;
-      point.y = e.clientY;
-      point = point.matrixTransform(screenCTM?.inverse());
-
-      return {
-        x: point.x,
-        y: point.y,
-      };
-    } else {
-      return {
-        x: e.clientX,
-        y: e.clientY,
-      };
-    }
+  function localPoint(e: PointerEvent | WheelEvent) {
+    return {
+      x: e.offsetX,
+      y: e.offsetY,
+    };
   }
 
   $: center = { x: $width / 2, y: $height / 2 };

--- a/packages/layerchart/src/lib/components/index.ts
+++ b/packages/layerchart/src/lib/components/index.ts
@@ -51,7 +51,7 @@ export { default as Tooltip } from './Tooltip.svelte';
 export { default as TooltipContext } from './TooltipContext.svelte';
 export { default as TooltipItem } from './TooltipItem.svelte';
 export { default as TooltipSeparator } from './TooltipSeparator.svelte';
+export { default as TransformContext, transformContext } from './TransformContext.svelte';
 export { default as Tree } from './Tree.svelte';
 export { default as Treemap } from './Treemap.svelte';
 export { default as Voronoi } from './Voronoi.svelte';
-export { default as Transform } from './Transform.svelte';

--- a/packages/layerchart/src/lib/components/layout/Canvas.svelte
+++ b/packages/layerchart/src/lib/components/layout/Canvas.svelte
@@ -1,0 +1,82 @@
+<script lang="ts">
+  import { getContext, onMount, setContext } from 'svelte';
+  import { writable } from 'svelte/store';
+  import { scaleCanvas } from 'layercake';
+
+  const { width, height, padding } = getContext('LayerCake');
+
+  /** The `<canvas>` tag. Useful for bindings. */
+  export let element: HTMLCanvasElement | undefined = undefined;
+
+  /** The `<canvas>`'s 2d context. Useful for bindings. */
+  export let context: CanvasRenderingContext2D = undefined;
+
+  /** The layer's z-index. */
+  export let zIndex = undefined;
+
+  /** Set this to `false` to set `pointer-events: none;` on the entire layer. */
+  export let pointerEvents: boolean | undefined = undefined;
+
+  /** Text to display if the browser won't render a canvas tag. You can also set arbitrary HTML via the "fallback" slot but this is fine if you just need text. If you use the "fallback" slot, this prop is ignored. */
+  export let fallback = '';
+
+  /** A string passed to the `aria-label` on the `<canvas>` tag. */
+  export let label: string | undefined = undefined;
+
+  /** A string passed to the `aria-labelledby` on the `<canvas>` tag. */
+  export let labelledBy: string | undefined = undefined;
+
+  /** A string passed to `aria-describedby` property on the `<canvas>` tag. */
+  export let describedBy: string | undefined = undefined;
+
+  /** Apply scale transform */
+  export let scale: number | undefined = undefined;
+
+  /** Apply scale transform */
+  export let translate = [0, 0];
+
+  const cntxt = {
+    ctx: writable({}),
+  };
+
+  onMount(() => {
+    context = element?.getContext('2d') as CanvasRenderingContext2D;
+  });
+
+  $: if (context) {
+    scaleCanvas(context, $width, $height);
+    context.clearRect(0, 0, $width, $height);
+
+    if (scale != null) {
+      context.scale(scale, scale);
+    }
+
+    if (translate.some((x) => x !== 0)) {
+      context.translate(translate[0], translate[1]);
+    }
+  }
+
+  $: cntxt.ctx.set(context);
+  setContext('canvas', cntxt);
+</script>
+
+<canvas
+  bind:this={element}
+  class="layercake-layout-canvas"
+  style:z-index={zIndex}
+  style:pointer-events={pointerEvents === false ? 'none' : null}
+  style:top="{$padding.top}px"
+  style:right="{$padding.right}px"
+  style:bottom="{$padding.bottom}px"
+  style:left="{$padding.left}px"
+  style="width:100%;height:100%;position:absolute;"
+  aria-label={label}
+  aria-labelledby={labelledBy}
+  aria-describedby={describedBy}
+>
+  <slot name="fallback">
+    {fallback || ''}
+  </slot>
+</canvas>
+
+<slot {element} {context}></slot>

--- a/packages/layerchart/src/lib/components/layout/Svg.svelte
+++ b/packages/layerchart/src/lib/components/layout/Svg.svelte
@@ -1,0 +1,81 @@
+<script lang="ts">
+  import { getContext } from 'svelte';
+  import { cls } from 'svelte-ux';
+  import { transformContext } from '../TransformContext.svelte';
+
+  /** The layer's `<svg>` tag. Useful for bindings. */
+  export let element: SVGElement | undefined = undefined;
+
+  /** The layer's `<g>` tag. Useful for bindings. */
+  export let innerElement: SVGGElement | undefined = undefined;
+
+  /** The layer's z-index. */
+  export let zIndex = undefined;
+
+  /** Set this to `false` to set `pointer-events: none;` on the entire layer. */
+  export let pointerEvents: boolean | undefined = undefined;
+
+  /** A string passed to the `viewBox` property on the `<svg>` tag. */
+  export let viewBox: string | undefined = undefined;
+
+  /** A string passed to the `aria-label` property on the `<svg>` tag. */
+  export let label: string | undefined = undefined;
+
+  /** A string passed to the `aria-labelledby property` on the `<svg>` tag. */
+  export let labelledBy: string | undefined = undefined;
+
+  /** A string passed to the `aria-describedby` property on the `<svg>` tag. */
+  export let describedBy: string | undefined = undefined;
+
+  /** Shorthand to set the contents of `<title></title>` for accessibility. You can also set arbitrary HTML via the "title" slot but this is a convenient shorthand. If you use the "title" slot, this prop is ignored. */
+  export let title: string | undefined = undefined;
+
+  const { containerWidth, containerHeight, width, height, padding } = getContext('LayerCake');
+
+  const { mode, scale, translate } = transformContext();
+
+  let transform = '';
+  $: if (mode === 'canvas') {
+    const center = { x: $width / 2, y: $height / 2 };
+    const newTranslate = {
+      x: $translate.x * $scale + center.x - center.x * $scale,
+      y: $translate.y * $scale + center.y - center.y * $scale,
+    };
+    transform = `translate(${newTranslate.x},${newTranslate.y}) scale(${$scale})`;
+  }
+</script>
+
+<svg
+  bind:this={element}
+  {viewBox}
+  width={$containerWidth}
+  height={$containerHeight}
+  style:z-index={zIndex}
+  class={cls(
+    'layercake-layout-svg',
+    'absolute top-0 left-0 overflow-visible',
+    pointerEvents === false && 'pointer-events-none'
+  )}
+  aria-label={label}
+  aria-labelledby={labelledBy}
+  aria-describedby={describedBy}
+  on:click
+>
+  <slot name="title">
+    {#if title}<title>{title}</title>{/if}
+  </slot>
+
+  <defs>
+    <slot name="defs"></slot>
+  </defs>
+
+  <g
+    bind:this={innerElement}
+    class="layercake-layout-svg_g"
+    transform="translate({$padding.left}, {$padding.top})"
+  >
+    <g {transform}>
+      <slot {element}></slot>
+    </g>
+  </g>
+</svg>

--- a/packages/layerchart/src/lib/docs/TransformControls.svelte
+++ b/packages/layerchart/src/lib/docs/TransformControls.svelte
@@ -7,7 +7,7 @@
     mdiMagnifyMinusOutline,
     mdiImageFilterCenterFocus,
   } from '@mdi/js';
-  import type Transform from '$lib/components/Transform.svelte';
+  import { transformContext } from '$lib/components/TransformContext.svelte';
 
   type Placement =
     | 'top-left'
@@ -20,9 +20,10 @@
     | 'bottom'
     | 'bottom-right';
 
-  export let transform: Transform;
   export let placement: Placement | undefined = 'top-right';
   export let orientation: 'horizontal' | 'vertical' = 'vertical';
+
+  const transform = transformContext();
 </script>
 
 <div
@@ -39,7 +40,8 @@
       'bottom-left': 'absolute bottom-0 left-0',
       bottom: 'absolute bottom-0 left-1/2 -translate-x-1/2',
       'bottom-right': 'absolute bottom-0 right-0',
-    }[placement]
+    }[placement],
+    $$props.class
   )}
 >
   <Tooltip title="Zoom in">

--- a/packages/layerchart/src/lib/docs/TransformDebug.svelte
+++ b/packages/layerchart/src/lib/docs/TransformDebug.svelte
@@ -1,0 +1,24 @@
+<script lang="ts">
+  import { format, cls } from 'svelte-ux';
+
+  import { transformContext } from '$lib/components/TransformContext.svelte';
+
+  const transform = transformContext();
+  const { translate, scale } = transform;
+</script>
+
+<div class={cls('bg-surface-300/50 rounded m-1 backdrop-blur p-2 tabular-nums', $$props.class)}>
+  <div class="grid gap-2 text-xs">
+    <div><span class="opacity-50">scale:</span> {format($scale, 'decimal')}</div>
+
+    <div>
+      <span class="opacity-50">translate:</span>
+      <div class="text-right">{format($translate.x, 'decimal')}</div>
+      <div class="text-right">{format($translate.y, 'decimal')}</div>
+
+      <span class="opacity-50">delta:</span>
+      <div class="text-right">{format($translate.deltaX, 'decimal')}</div>
+      <div class="text-right">{format($translate.deltaY, 'decimal')}</div>
+    </div>
+  </div>
+</div>

--- a/packages/layerchart/src/routes/_NavMenu.svelte
+++ b/packages/layerchart/src/routes/_NavMenu.svelte
@@ -64,7 +64,14 @@
       'Spline',
       'Threshold',
     ],
-    Interactions: ['Tooltip', 'TooltipContext', 'Highlight', 'HitCanvas', 'Voronoi', 'Transform'],
+    Interactions: [
+      'Highlight',
+      'HitCanvas',
+      'Tooltip',
+      'TooltipContext',
+      'TransformContext',
+      'Voronoi',
+    ],
     Geo: [
       'GeoContext',
       'GeoCircle',

--- a/packages/layerchart/src/routes/docs/components/TransformContext/+page.svelte
+++ b/packages/layerchart/src/routes/docs/components/TransformContext/+page.svelte
@@ -8,7 +8,6 @@
   import Circle from '$lib/components/Circle.svelte';
   import Spline from '$lib/components/Spline.svelte';
   import Points from '$lib/components/Points.svelte';
-  import Transform from '$lib/components/Transform.svelte';
 
   import Preview from '$lib/docs/Preview.svelte';
   import TransformControls from '$lib/docs/TransformControls.svelte';
@@ -16,7 +15,6 @@
   import { getSpiral } from '$lib/utils/genData.js';
   import CurveMenuField from '$lib/docs/CurveMenuField.svelte';
 
-  let transform: Transform;
   let pointCount = 500;
   let angle = 137.5; //
   let showPoints = true;
@@ -58,31 +56,34 @@
 
 <Preview {data}>
   <div class="h-[500px] p-4 border rounded relative overflow-hidden">
-    <TransformControls {transform} />
-    <Chart {data} x="x" y="y">
+    <Chart
+      {data}
+      x="x"
+      y="y"
+      transform={{
+        mode: 'canvas',
+        scroll: scrollMode,
+        tweened: { duration: 800, easing: cubicOut },
+      }}
+    >
+      <TransformControls />
       <Svg>
-        <Transform
-          bind:this={transform}
-          scroll={scrollMode}
-          tweened={{ duration: 800, easing: cubicOut }}
-        >
-          {#if showPath}
-            <Spline {curve} {tweened} />
-          {/if}
-          {#if showPoints}
-            <Points let:points>
-              {#each points as point, index}
-                <Circle
-                  cx={point.x}
-                  cy={point.y}
-                  r={2}
-                  class={index % 2 ? 'fill-primary' : 'fill-secondary'}
-                  {tweened}
-                />
-              {/each}
-            </Points>
-          {/if}
-        </Transform>
+        {#if showPath}
+          <Spline {curve} {tweened} />
+        {/if}
+        {#if showPoints}
+          <Points let:points>
+            {#each points as point, index}
+              <Circle
+                cx={point.x}
+                cy={point.y}
+                r={2}
+                class={index % 2 ? 'fill-primary' : 'fill-secondary'}
+                {tweened}
+              />
+            {/each}
+          </Points>
+        {/if}
       </Svg>
     </Chart>
   </div>

--- a/packages/layerchart/src/routes/docs/components/TransformContext/+page.ts
+++ b/packages/layerchart/src/routes/docs/components/TransformContext/+page.ts
@@ -1,5 +1,5 @@
 import api from '$lib/components/TransformContext.svelte?raw&sveld';
-import source from '$lib/components/Transform.svelte?raw';
+import source from '$lib/components/TransformContext.svelte?raw';
 import pageSource from './+page.svelte?raw';
 
 export async function load() {

--- a/packages/layerchart/src/routes/docs/components/TransformContext/+page.ts
+++ b/packages/layerchart/src/routes/docs/components/TransformContext/+page.ts
@@ -1,4 +1,4 @@
-import api from '$lib/components/Transform.svelte?raw&sveld';
+import api from '$lib/components/TransformContext.svelte?raw&sveld';
 import source from '$lib/components/Transform.svelte?raw';
 import pageSource from './+page.svelte?raw';
 
@@ -9,6 +9,7 @@ export async function load() {
       source,
       pageSource,
       related: [
+        'components/Chart',
         'examples/Pack',
         'examples/Tree',
         'examples/ZoomableMap',

--- a/packages/layerchart/src/routes/docs/examples/AnimatedGlobe/+page.svelte
+++ b/packages/layerchart/src/routes/docs/examples/AnimatedGlobe/+page.svelte
@@ -128,7 +128,6 @@
         applyTransform: ['rotate'],
       }}
       transform={{
-        mode: 'manual',
         scroll: 'none',
         spring: { stiffness: 0.04 },
       }}
@@ -199,13 +198,14 @@
         </div>
       {/each}
     </div>
+
     <Chart
       geo={{
         projection: geoOrthographic,
         fitGeojson: countries,
         applyTransform: ['rotate'],
       }}
-      transform={{ mode: 'manual', scroll: 'none', spring: { stiffness: 0.04 } }}
+      transform={{ scroll: 'none', spring: { stiffness: 0.04 } }}
     >
       <Canvas>
         <GeoPath geojson={{ type: 'Sphere' }} class="fill-blue-400/50" />

--- a/packages/layerchart/src/routes/docs/examples/AnimatedGlobe/+page.svelte
+++ b/packages/layerchart/src/routes/docs/examples/AnimatedGlobe/+page.svelte
@@ -24,12 +24,18 @@
   const countries = feature(data.geojson, data.geojson.objects.countries);
 
   let transformContext: TransformContext;
+  let transformContext2: TransformContext; // second instance for canvas example
 
   let selectedFeature;
   $: if (selectedFeature) {
     const centroid = geoCentroid(selectedFeature);
 
     transformContext.translate.set({
+      x: -centroid[0],
+      y: -centroid[1],
+    });
+
+    transformContext2.translate.set({
       x: -centroid[0],
       y: -centroid[1],
     });
@@ -206,6 +212,7 @@
         applyTransform: ['rotate'],
       }}
       transform={{ scroll: 'none', spring: { stiffness: 0.04 } }}
+      bind:transformContext={transformContext2}
     >
       <Canvas>
         <GeoPath geojson={{ type: 'Sphere' }} class="fill-blue-400/50" />

--- a/packages/layerchart/src/routes/docs/examples/AnimatedGlobe/+page.svelte
+++ b/packages/layerchart/src/routes/docs/examples/AnimatedGlobe/+page.svelte
@@ -1,5 +1,4 @@
 <script lang="ts">
-  import { spring } from 'svelte/motion';
   import { geoOrthographic, geoCentroid } from 'd3-geo';
   import { feature } from 'topojson-client';
   import { index } from 'd3-array';
@@ -14,17 +13,15 @@
   import Graticule from '$lib/components/Graticule.svelte';
   import Tooltip from '$lib/components/Tooltip.svelte';
   import TransformContext from '$lib/components/TransformContext.svelte';
+
+  import GeoDebug from '$lib/docs/GeoDebug.svelte';
+  import TransformDebug from '$lib/docs/TransformDebug.svelte';
+
   import { timings } from './timings.js';
 
   export let data;
 
   const countries = feature(data.geojson, data.geojson.objects.countries);
-
-  const springOptions = { stiffness: 0.04 };
-  const yaw = spring(0, springOptions);
-  const pitch = spring(0, springOptions);
-  const roll = spring(0, springOptions);
-  const sensitivity = 75;
 
   let transformContext: TransformContext;
 
@@ -32,13 +29,6 @@
   $: if (selectedFeature) {
     const centroid = geoCentroid(selectedFeature);
 
-    // $yaw = -centroid[0];
-    // $pitch = -centroid[1];
-
-    // transformContext.zoomTo({
-    //   x: -centroid[0],
-    //   y: -centroid[1],
-    // });
     transformContext.translate.set({
       x: -centroid[0],
       y: -centroid[1],
@@ -93,6 +83,8 @@
     currentIndex = -1;
     selectedFeature = null;
   }
+
+  let debug = false;
 </script>
 
 <h1>Examples</h1>
@@ -134,30 +126,24 @@
         projection: geoOrthographic,
         fitGeojson: countries,
         applyTransform: ['rotate'],
-        // rotate: {
-        //   yaw: $yaw,
-        //   pitch: $pitch,
-        //   roll: $roll,
-        // },
       }}
-      transform={{ mode: 'manual', scroll: 'none', spring: { stiffness: 0.04 } }}
+      transform={{
+        mode: 'manual',
+        scroll: 'none',
+        spring: { stiffness: 0.04 },
+      }}
       bind:transformContext
-      on:transform={(e) => {
-        // $yaw = e.detail.translate.x * (sensitivity / projection.scale());
-        // $pitch = -e.detail.translate.y * (sensitivity / projection.scale());
-      }}
       tooltip={{ mode: 'manual' }}
       let:tooltip
     >
+      {#if debug}
+        <div class="absolute bottom-0 right-0 z-10 grid gap-1">
+          <GeoDebug />
+          <TransformDebug />
+        </div>
+      {/if}
+
       <Svg>
-        <!-- <Transform
-          mode="manual"
-          scroll="none"
-          on:transform={(e) => {
-            $yaw = e.detail.translate.x * (sensitivity / projection.scale());
-            $pitch = -e.detail.translate.y * (sensitivity / projection.scale());
-          }}
-        > -->
         <GeoPath geojson={{ type: 'Sphere' }} class="fill-blue-400/50" />
         <Graticule class="stroke-surface-content/20" />
         {#each countries.features as country}
@@ -173,7 +159,6 @@
             {tooltip}
           />
         {/each}
-        <!-- </Transform> -->
       </Svg>
 
       <Tooltip>
@@ -219,11 +204,6 @@
         projection: geoOrthographic,
         fitGeojson: countries,
         applyTransform: ['rotate'],
-        // rotate: {
-        //   yaw: $yaw,
-        //   pitch: $pitch,
-        //   roll: $roll,
-        // },
       }}
       transform={{ mode: 'manual', scroll: 'none', spring: { stiffness: 0.04 } }}
     >

--- a/packages/layerchart/src/routes/docs/examples/AnimatedGlobe/+page.svelte
+++ b/packages/layerchart/src/routes/docs/examples/AnimatedGlobe/+page.svelte
@@ -13,7 +13,7 @@
   import GeoPath from '$lib/components/GeoPath.svelte';
   import Graticule from '$lib/components/Graticule.svelte';
   import Tooltip from '$lib/components/Tooltip.svelte';
-  import Transform from '$lib/components/Transform.svelte';
+  import TransformContext from '$lib/components/TransformContext.svelte';
   import { timings } from './timings.js';
 
   export let data;
@@ -26,11 +26,23 @@
   const roll = spring(0, springOptions);
   const sensitivity = 75;
 
+  let transformContext: TransformContext;
+
   let selectedFeature;
   $: if (selectedFeature) {
     const centroid = geoCentroid(selectedFeature);
-    $yaw = -centroid[0];
-    $pitch = -centroid[1];
+
+    // $yaw = -centroid[0];
+    // $pitch = -centroid[1];
+
+    // transformContext.zoomTo({
+    //   x: -centroid[0],
+    //   y: -centroid[1],
+    // });
+    transformContext.translate.set({
+      x: -centroid[0],
+      y: -centroid[1],
+    });
   }
 
   // Animate to Yakko's song
@@ -116,45 +128,52 @@
         </div>
       {/each}
     </div>
+
     <Chart
       geo={{
         projection: geoOrthographic,
         fitGeojson: countries,
-        rotate: {
-          yaw: $yaw,
-          pitch: $pitch,
-          roll: $roll,
-        },
+        applyTransform: ['rotate'],
+        // rotate: {
+        //   yaw: $yaw,
+        //   pitch: $pitch,
+        //   roll: $roll,
+        // },
+      }}
+      transform={{ mode: 'manual', scroll: 'none', spring: { stiffness: 0.04 } }}
+      bind:transformContext
+      on:transform={(e) => {
+        // $yaw = e.detail.translate.x * (sensitivity / projection.scale());
+        // $pitch = -e.detail.translate.y * (sensitivity / projection.scale());
       }}
       tooltip={{ mode: 'manual' }}
       let:tooltip
-      let:projection
     >
       <Svg>
-        <Transform
+        <!-- <Transform
           mode="manual"
           scroll="none"
           on:transform={(e) => {
             $yaw = e.detail.translate.x * (sensitivity / projection.scale());
             $pitch = -e.detail.translate.y * (sensitivity / projection.scale());
           }}
-        >
-          <GeoPath geojson={{ type: 'Sphere' }} class="fill-blue-400/50" />
-          <Graticule class="stroke-surface-content/20" />
-          {#each countries.features as country}
-            <GeoPath
-              geojson={country}
-              class={cls(
-                'stroke-surface-content/50 fill-white cursor-pointer',
-                selectedFeature === country
-                  ? 'stroke-primary-900 fill-primary'
-                  : 'hover:fill-gray-200'
-              )}
-              on:click={(e) => (selectedFeature = country)}
-              {tooltip}
-            />
-          {/each}
-        </Transform>
+        > -->
+        <GeoPath geojson={{ type: 'Sphere' }} class="fill-blue-400/50" />
+        <Graticule class="stroke-surface-content/20" />
+        {#each countries.features as country}
+          <GeoPath
+            geojson={country}
+            class={cls(
+              'stroke-surface-content/50 fill-white cursor-pointer',
+              selectedFeature === country
+                ? 'stroke-primary-900 fill-primary'
+                : 'hover:fill-gray-200'
+            )}
+            on:click={(e) => (selectedFeature = country)}
+            {tooltip}
+          />
+        {/each}
+        <!-- </Transform> -->
       </Svg>
 
       <Tooltip>
@@ -199,12 +218,14 @@
       geo={{
         projection: geoOrthographic,
         fitGeojson: countries,
-        rotate: {
-          yaw: $yaw,
-          pitch: $pitch,
-          roll: $roll,
-        },
+        applyTransform: ['rotate'],
+        // rotate: {
+        //   yaw: $yaw,
+        //   pitch: $pitch,
+        //   roll: $roll,
+        // },
       }}
+      transform={{ mode: 'manual', scroll: 'none', spring: { stiffness: 0.04 } }}
     >
       <Canvas>
         <GeoPath geojson={{ type: 'Sphere' }} class="fill-blue-400/50" />

--- a/packages/layerchart/src/routes/docs/examples/BubbleMap/+page.svelte
+++ b/packages/layerchart/src/routes/docs/examples/BubbleMap/+page.svelte
@@ -131,7 +131,7 @@
 <h2>Canvas</h2>
 
 <Preview data={states}>
-  <div class="h-[600px] mt-10">
+  <div class="h-[600px]">
     <Chart
       geo={{
         projection: geoIdentity,

--- a/packages/layerchart/src/routes/docs/examples/EarthquakeGlobe/+page.svelte
+++ b/packages/layerchart/src/routes/docs/examples/EarthquakeGlobe/+page.svelte
@@ -92,7 +92,6 @@
         applyTransform: ['rotate'],
       }}
       transform={{
-        mode: 'manual',
         scroll: 'none',
         tweened: { duration: 800, easing: cubicOut },
       }}

--- a/packages/layerchart/src/routes/docs/examples/EarthquakeGlobe/+page.svelte
+++ b/packages/layerchart/src/routes/docs/examples/EarthquakeGlobe/+page.svelte
@@ -12,7 +12,7 @@
   import Graticule from '$lib/components/Graticule.svelte';
   import Tooltip from '$lib/components/Tooltip.svelte';
   import TooltipItem from '$lib/components/TooltipItem.svelte';
-  import Transform from '$lib/components/Transform.svelte';
+  import TransformContext from '$lib/components/TransformContext.svelte';
   import { scaleSqrt } from 'd3-scale';
 
   export let data;
@@ -22,17 +22,19 @@
 
   const countries = feature(data.geojson, data.geojson.objects.countries);
 
-  let yaw = 0;
-  let pitch = 0;
-  let roll = 0;
-  let sensitivity = 75;
+  let transformContext: TransformContext;
 
   let velocity = 3;
   let isSpinning = false;
   const timer = timerStore({
     delay: 1,
     onTick() {
-      yaw += velocity * 0.1;
+      transformContext.translate.update((value) => {
+        return {
+          x: (value.x += velocity),
+          y: value.y,
+        };
+      });
     },
     disabled: !isSpinning,
   });
@@ -87,51 +89,42 @@
       geo={{
         projection: geoOrthographic,
         fitGeojson: countries,
-        rotate: {
-          yaw,
-          pitch,
-          roll,
-        },
+        applyTransform: ['rotate'],
       }}
+      transform={{
+        mode: 'manual',
+        scroll: 'none',
+        tweened: { duration: 800, easing: cubicOut },
+      }}
+      on:dragstart={() => timer.stop()}
+      on:dragend={() => {
+        if (isSpinning) {
+          // Restart
+          timer.start();
+        }
+      }}
+      bind:transformContext
       tooltip={{ mode: 'manual' }}
       let:tooltip
-      let:projection
       let:rScale
     >
       <Svg>
-        <Transform
-          mode="manual"
-          scroll="none"
-          tweened={{ duration: 800, easing: cubicOut }}
-          on:dragstart={() => timer.stop()}
-          on:dragend={() => {
-            if (isSpinning) {
-              // Restart
-              timer.start();
-            }
-          }}
-          on:transform={(e) => {
-            yaw = e.detail.translate.x * (sensitivity / projection.scale());
-            pitch = -e.detail.translate.y * (sensitivity / projection.scale());
-          }}
-        >
-          <GeoPath geojson={{ type: 'Sphere' }} class="fill-blue-400/50" />
+        <GeoPath geojson={{ type: 'Sphere' }} class="fill-blue-400/50" />
 
-          <Graticule class="stroke-surface-content/20" />
+        <Graticule class="stroke-surface-content/20" />
 
-          <GeoPath geojson={countries} class="stroke-surface-100/30 fill-surface-content" />
-          <GeoPath geojson={data.tectonicPlates} class="stroke-danger-100/30" />
+        <GeoPath geojson={countries} class="stroke-surface-100/30 fill-surface-content" />
+        <GeoPath geojson={data.tectonicPlates} class="stroke-danger-100/30" />
 
-          {#each data.earthquakes as eq}
-            <GeoCircle
-              center={[eq.longitude, eq.latitude]}
-              radius={rScale(Math.exp(eq.magnitude))}
-              class="stroke-danger fill-danger/20"
-              on:pointermove={(e) => tooltip?.show(e, eq)}
-              on:pointerleave={(e) => tooltip?.hide()}
-            />
-          {/each}
-        </Transform>
+        {#each data.earthquakes as eq}
+          <GeoCircle
+            center={[eq.longitude, eq.latitude]}
+            radius={rScale(Math.exp(eq.magnitude))}
+            class="stroke-danger fill-danger/20"
+            on:pointermove={(e) => tooltip?.show(e, eq)}
+            on:pointerleave={(e) => tooltip?.hide()}
+          />
+        {/each}
       </Svg>
 
       <Tooltip header={(d) => d.place} let:data>

--- a/packages/layerchart/src/routes/docs/examples/EclipsesGlobe/+page.svelte
+++ b/packages/layerchart/src/routes/docs/examples/EclipsesGlobe/+page.svelte
@@ -99,7 +99,6 @@
         applyTransform: ['rotate'],
       }}
       transform={{
-        mode: 'manual',
         scroll: 'none',
         tweened: { duration: 800, easing: cubicOut },
       }}

--- a/packages/layerchart/src/routes/docs/examples/EclipsesGlobe/+page.svelte
+++ b/packages/layerchart/src/routes/docs/examples/EclipsesGlobe/+page.svelte
@@ -23,7 +23,7 @@
   import Graticule from '$lib/components/Graticule.svelte';
   import Tooltip from '$lib/components/Tooltip.svelte';
   import TooltipItem from '$lib/components/TooltipItem.svelte';
-  import Transform from '$lib/components/Transform.svelte';
+  import TransformContext from '$lib/components/TransformContext.svelte';
   import Legend from '$lib/components/Legend.svelte';
 
   export let data;
@@ -31,17 +31,19 @@
   const countries = feature(data.geojson, data.geojson.objects.countries);
   const eclipses = feature(data.eclipses, data.eclipses.objects.eclipses);
 
-  let yaw = 0;
-  let pitch = 0;
-  let roll = 0;
-  let sensitivity = 75;
+  let transformContext: TransformContext;
 
   let velocity = 3;
   let isSpinning = false;
   const timer = timerStore({
     delay: 1,
     onTick() {
-      yaw += velocity * 0.1;
+      transformContext.translate.update((value) => {
+        return {
+          x: (value.x += velocity),
+          y: value.y,
+        };
+      });
     },
     disabled: !isSpinning,
   });
@@ -94,16 +96,24 @@
       geo={{
         projection: geoOrthographic,
         fitGeojson: countries,
-        rotate: {
-          yaw,
-          pitch,
-          roll,
-        },
+        applyTransform: ['rotate'],
       }}
+      transform={{
+        mode: 'manual',
+        scroll: 'none',
+        tweened: { duration: 800, easing: cubicOut },
+      }}
+      on:dragstart={() => timer.stop()}
+      on:dragend={() => {
+        if (isSpinning) {
+          // Restart
+          timer.start();
+        }
+      }}
+      bind:transformContext
       padding={{ top: 60 }}
       tooltip={{ mode: 'manual' }}
       let:tooltip
-      let:projection
     >
       <Legend
         scale={colorScale}
@@ -112,41 +122,21 @@
       />
 
       <Svg>
-        <Transform
-          mode="manual"
-          scroll="none"
-          tweened={{ duration: 800, easing: cubicOut }}
-          on:dragstart={() => timer.stop()}
-          on:dragend={() => {
-            if (isSpinning) {
-              // Restart
-              timer.start();
-            }
-          }}
-          on:transform={(e) => {
-            yaw = e.detail.translate.x * (sensitivity / projection.scale());
-            pitch = -e.detail.translate.y * (sensitivity / projection.scale());
-          }}
-        >
+        <GeoPath geojson={{ type: 'Sphere' }} class="fill-surface-200 stroke-surface-content/20" />
+        <Graticule class="stroke-surface-content/20" />
+        <GeoPath geojson={countries} class="stroke-surface-100/30 fill-surface-content" />
+
+        {#each eclipses.features as feature}
+          {@const hasColor = tooltip.data == null || tooltip.data.ID === feature.properties.ID}
+
           <GeoPath
-            geojson={{ type: 'Sphere' }}
-            class="fill-surface-200 stroke-surface-content/20"
+            geojson={feature}
+            fill={hasColor ? colorScale(feature.properties.Date) : undefined}
+            class={cls('transition-colors', !hasColor && 'fill-surface-content/10')}
+            on:pointermove={(e) => tooltip?.show(e, feature.properties)}
+            on:pointerleave={(e) => tooltip?.hide()}
           />
-          <Graticule class="stroke-surface-content/20" />
-          <GeoPath geojson={countries} class="stroke-surface-100/30 fill-surface-content" />
-
-          {#each eclipses.features as feature}
-            {@const hasColor = tooltip.data == null || tooltip.data.ID === feature.properties.ID}
-
-            <GeoPath
-              geojson={feature}
-              fill={hasColor ? colorScale(feature.properties.Date) : undefined}
-              class={cls('transition-colors', !hasColor && 'fill-surface-content/10')}
-              on:pointermove={(e) => tooltip?.show(e, feature.properties)}
-              on:pointerleave={(e) => tooltip?.hide()}
-            />
-          {/each}
-        </Transform>
+        {/each}
       </Svg>
 
       <Tooltip header={(d) => format(d.Date, PeriodType.Day, { variant: 'long' })} />

--- a/packages/layerchart/src/routes/docs/examples/GeoProjection/+page.svelte
+++ b/packages/layerchart/src/routes/docs/examples/GeoProjection/+page.svelte
@@ -41,13 +41,13 @@
       ? geojson.features.filter((f) => f.properties.name === 'United States of America')
       : geojson.features;
 
+  let scale = 0;
   let yaw = 0;
   let pitch = 0;
   let roll = 0;
-  let scale = 0;
 </script>
 
-<div class="grid grid-cols-[1fr,1fr,1fr,1fr,1fr,auto] gap-2 my-2">
+<div class="grid grid-cols-[1fr,1fr,auto] gap-2 my-2">
   <SelectField
     label="Projections"
     options={projections}
@@ -56,13 +56,15 @@
     toggleIcon={null}
     stepper
   />
-  <RangeField label="Yaw" bind:value={yaw} min={-360} max={360} />
-  <RangeField label="Pitch" bind:value={pitch} min={-90} max={90} />
-  <RangeField label="Roll" bind:value={roll} min={-180} max={180} />
   <RangeField label="Scale" bind:value={scale} min={-100} max={3000} />
   <Field label="Detail" let:id>
     <Switch bind:checked={detailed} {id} />
   </Field>
+</div>
+<div class="grid grid-cols-[1fr,1fr,1fr] gap-2 my-2">
+  <RangeField label="Yaw" bind:value={yaw} min={-360} max={360} />
+  <RangeField label="Pitch" bind:value={pitch} min={-90} max={90} />
+  <RangeField label="Roll" bind:value={roll} min={-180} max={180} />
 </div>
 
 <h1>Examples</h1>

--- a/packages/layerchart/src/routes/docs/examples/GeoProjection/+page.svelte
+++ b/packages/layerchart/src/routes/docs/examples/GeoProjection/+page.svelte
@@ -83,6 +83,7 @@
           roll,
         },
         scale,
+        // applyTransform: ['rotate'],
       }}
       padding={{ left: 100, right: 100 }}
       tooltip={{ mode: 'manual' }}
@@ -118,6 +119,7 @@
           roll,
         },
         scale,
+        // applyTransform: ['rotate'],
       }}
     >
       <Canvas>

--- a/packages/layerchart/src/routes/docs/examples/LoftedArcs/+page.svelte
+++ b/packages/layerchart/src/routes/docs/examples/LoftedArcs/+page.svelte
@@ -86,7 +86,6 @@
         applyTransform: ['rotate'],
       }}
       transform={{
-        mode: 'manual',
         scroll: 'none',
         tweened: { duration: 800, easing: cubicOut },
       }}

--- a/packages/layerchart/src/routes/docs/examples/LoftedArcs/+page.svelte
+++ b/packages/layerchart/src/routes/docs/examples/LoftedArcs/+page.svelte
@@ -13,7 +13,6 @@
   import GeoPath from '$lib/components/GeoPath.svelte';
   import GeoEdgeFade from '$lib/components/GeoEdgeFade.svelte';
   import Graticule from '$lib/components/Graticule.svelte';
-  import Transform from '$lib/components/Transform.svelte';
 
   import links from '../_data/geo/world-links.json';
   import GeoSpline from '$lib/components/GeoSpline.svelte';
@@ -22,11 +21,6 @@
   export let data;
 
   const countries = feature(data.geojson, data.geojson.objects.countries);
-
-  let yaw = 0;
-  let pitch = 0;
-  let roll = 0;
-  let sensitivity = 75;
 
   let debug = false;
 
@@ -89,49 +83,35 @@
       geo={{
         projection: geoOrthographic,
         fitGeojson: countries,
-        rotate: {
-          yaw,
-          pitch,
-          roll,
-        },
+        applyTransform: ['rotate'],
+      }}
+      transform={{
+        mode: 'manual',
+        scroll: 'none',
+        tweened: { duration: 800, easing: cubicOut },
       }}
       padding={{ top: 80, bottom: 80 }}
-      let:projection
     >
       {#if debug}
         <GeoDebug class="absolute top-0 right-0 z-10" />
       {/if}
       <Svg>
-        <Transform
-          mode="manual"
-          scroll="none"
-          tweened={{ duration: 800, easing: cubicOut }}
-          on:transform={(e) => {
-            yaw = e.detail.translate.x * (sensitivity / projection.scale());
-            pitch = -e.detail.translate.y * (sensitivity / projection.scale());
-          }}
-        >
+        <GeoPath geojson={{ type: 'Sphere' }} class="fill-blue-400/50" />
+        <Graticule class="stroke-surface-content/20 pointer-events-none" />
+        {#each countries.features as country}
           <GeoPath
-            geojson={{ type: 'Sphere' }}
-            class="fill-blue-400/50"
-            on:click={() => (yaw += 1)}
+            geojson={country}
+            class="stroke-surface-content/50 fill-white pointer-events-none"
           />
-          <Graticule class="stroke-surface-content/20 pointer-events-none" />
-          {#each countries.features as country}
-            <GeoPath
-              geojson={country}
-              class="stroke-surface-content/50 fill-white pointer-events-none"
-            />
-          {/each}
-          {#each links as link}
-            <GeoEdgeFade {link}>
-              <GeoPoint lat={link.source[1]} long={link.source[0]} r={2} class="fill-black" />
-              <GeoPoint lat={link.target[1]} long={link.target[0]} r={2} class="fill-black" />
-              <GeoSpline {link} class="stroke-gray-500/30 stroke-2" />
-              <GeoSpline {link} class="stroke-danger stroke-2" loft={1.3} />
-            </GeoEdgeFade>
-          {/each}
-        </Transform>
+        {/each}
+        {#each links as link}
+          <GeoEdgeFade {link}>
+            <GeoPoint lat={link.source[1]} long={link.source[0]} r={2} class="fill-black" />
+            <GeoPoint lat={link.target[1]} long={link.target[0]} r={2} class="fill-black" />
+            <GeoSpline {link} class="stroke-gray-500/30 stroke-2" />
+            <GeoSpline {link} class="stroke-danger stroke-2" loft={1.3} />
+          </GeoEdgeFade>
+        {/each}
       </Svg>
     </Chart>
   </div>

--- a/packages/layerchart/src/routes/docs/examples/SketchyGlobe/+page.svelte
+++ b/packages/layerchart/src/routes/docs/examples/SketchyGlobe/+page.svelte
@@ -90,7 +90,6 @@
         applyTransform: ['rotate'],
       }}
       transform={{
-        mode: 'manual',
         scroll: 'none',
         tweened: { duration: 800, easing: cubicOut },
       }}

--- a/packages/layerchart/src/routes/docs/examples/SubmarineCablesGlobe/+page.svelte
+++ b/packages/layerchart/src/routes/docs/examples/SubmarineCablesGlobe/+page.svelte
@@ -86,7 +86,6 @@
         applyTransform: ['rotate'],
       }}
       transform={{
-        mode: 'manual',
         scroll: 'none',
         tweened: { duration: 800, easing: cubicOut },
       }}

--- a/packages/layerchart/src/routes/docs/examples/TranslucentGlobe/+page.svelte
+++ b/packages/layerchart/src/routes/docs/examples/TranslucentGlobe/+page.svelte
@@ -80,7 +80,6 @@
         applyTransform: ['rotate'],
       }}
       transform={{
-        mode: 'manual',
         scroll: 'none',
         tweened: { duration: 800, easing: cubicOut },
       }}

--- a/packages/layerchart/src/routes/docs/examples/TranslucentGlobe/+page.svelte
+++ b/packages/layerchart/src/routes/docs/examples/TranslucentGlobe/+page.svelte
@@ -11,23 +11,25 @@
   import GeoPath from '$lib/components/GeoPath.svelte';
   import Graticule from '$lib/components/Graticule.svelte';
   import Tooltip from '$lib/components/Tooltip.svelte';
-  import Transform from '$lib/components/Transform.svelte';
+  import TransformContext from '$lib/components/TransformContext.svelte';
 
   export let data;
 
   const countries = feature(data.geojson, data.geojson.objects.countries);
 
-  let yaw = 0;
-  let pitch = 0;
-  let roll = 0;
-  let sensitivity = 75;
+  let transformContext: TransformContext;
 
   let velocity = 3;
   let isSpinning = false;
   const timer = timerStore({
     delay: 1,
     onTick() {
-      yaw += velocity * 0.1;
+      transformContext.translate.update((value) => {
+        return {
+          x: (value.x += velocity),
+          y: value.y,
+        };
+      });
     },
     disabled: !isSpinning,
   });
@@ -75,62 +77,55 @@
       geo={{
         projection: geoOrthographic,
         fitGeojson: countries,
-        rotate: {
-          yaw,
-          pitch,
-          roll,
-        },
+        applyTransform: ['rotate'],
       }}
+      transform={{
+        mode: 'manual',
+        scroll: 'none',
+        tweened: { duration: 800, easing: cubicOut },
+      }}
+      on:dragstart={() => timer.stop()}
+      on:dragend={() => {
+        if (isSpinning) {
+          // Restart
+          timer.start();
+        }
+      }}
+      bind:transformContext
       tooltip={{ mode: 'manual' }}
       let:tooltip
       let:projection
     >
+      {@const [yaw, pitch, roll] = projection.rotate()}
       <Svg>
-        <Transform
-          mode="manual"
-          scroll="none"
-          tweened={{ duration: 800, easing: cubicOut }}
-          on:dragstart={() => timer.stop()}
-          on:dragend={() => {
-            if (isSpinning) {
-              // Restart
-              timer.start();
-            }
-          }}
-          on:transform={(e) => {
-            yaw = e.detail.translate.x * (sensitivity / projection.scale());
-            pitch = -e.detail.translate.y * (sensitivity / projection.scale());
-          }}
+        <GeoPath geojson={{ type: 'Sphere' }} class="fill-blue-400/20" />
+
+        <!-- Back -->
+        <GeoContext
+          projection={geoOrthographic}
+          fitGeojson={countries}
+          rotate={{ yaw: yaw + 180, pitch: -pitch, roll: -roll }}
+          reflectX
         >
-          <GeoPath geojson={{ type: 'Sphere' }} class="fill-blue-400/20" />
-
-          <!-- Back -->
-          <GeoContext
-            projection={geoOrthographic}
-            fitGeojson={countries}
-            rotate={{ yaw: yaw + 180, pitch: -pitch, roll: -roll }}
-            reflectX
-          >
-            <Graticule class="stroke-surface-content/5" />
-            {#each countries.features as country}
-              <GeoPath
-                geojson={country}
-                class="stroke-surface-content/5 fill-surface-content/10"
-                reflectX
-              />
-            {/each}
-          </GeoContext>
-
-          <!-- Front -->
-          <Graticule class="stroke-surface-content/20" />
+          <Graticule class="stroke-surface-content/5" />
           {#each countries.features as country}
             <GeoPath
               geojson={country}
-              class="stroke-surface-100/30 fill-surface-content/70 cursor-pointer hover:fill-primary/70"
-              {tooltip}
+              class="stroke-surface-content/5 fill-surface-content/10"
+              reflectX
             />
           {/each}
-        </Transform>
+        </GeoContext>
+
+        <!-- Front -->
+        <Graticule class="stroke-surface-content/20" />
+        {#each countries.features as country}
+          <GeoPath
+            geojson={country}
+            class="stroke-surface-100/30 fill-surface-content/70 cursor-pointer hover:fill-primary/70"
+            {tooltip}
+          />
+        {/each}
       </Svg>
 
       <Tooltip>

--- a/packages/layerchart/src/routes/docs/examples/Tree/+page.svelte
+++ b/packages/layerchart/src/routes/docs/examples/Tree/+page.svelte
@@ -11,7 +11,6 @@
   import Rect from '$lib/components/Rect.svelte';
   import Text from '$lib/components/Text.svelte';
   import Tree from '$lib/components/Tree.svelte';
-  import Transform from '$lib/components/Transform.svelte';
 
   import Preview from '$lib/docs/Preview.svelte';
   import TransformControls from '$lib/docs/TransformControls.svelte';
@@ -30,16 +29,6 @@
   let curve = curveBumpX;
   let layout = 'chart';
   let selected;
-  let transform: Transform;
-
-  /*
-	$: if (transform && selected) {
-		transform.zoomTo({
-			x: (orientation === 'horizontal' ? selected.y : selected.x),
-			y: (orientation === 'horizontal' ? selected.x : selected.y)
-		})
-	}
-	*/
 
   function getNodeKey(node) {
     return node.data.name + node.depth;
@@ -87,62 +76,68 @@
 
 <Preview data={complexDataHierarchy}>
   <div class="h-[800px] p-4 border rounded overflow-hidden relative">
-    <TransformControls {transform} orientation="horizontal" />
     <Chart
       data={complexDataHierarchy}
       padding={{ top: 24, left: nodeWidth / 2, right: nodeWidth / 2 }}
+      transform={{ mode: 'canvas', tweened: { duration: 800, easing: cubicOut } }}
+      let:transform
     >
-      <Svg>
-        <Transform bind:this={transform} tweened={{ duration: 800, easing: cubicOut }}>
-          <Tree let:nodes let:links {orientation} nodeSize={layout === 'node' ? nodeSize : null}>
-            <g class="opacity-20">
-              {#each links as link (getNodeKey(link.source) + '_' + getNodeKey(link.target))}
-                <Link data={link} {orientation} {curve} tweened class="stroke-surface-content" />
-              {/each}
-            </g>
+      <TransformControls orientation="horizontal" class="-m-2" />
 
-            {#each nodes as node (getNodeKey(node))}
-              <Group
-                x={(orientation === 'horizontal' ? node.y : node.x) - nodeWidth / 2}
-                y={(orientation === 'horizontal' ? node.x : node.y) - nodeHeight / 2}
-                tweened
-                on:click={() => {
-                  if (expandedNodeNames.includes(node.data.name)) {
-                    expandedNodeNames = expandedNodeNames.filter((name) => name !== node.data.name);
-                  } else {
-                    expandedNodeNames = [...expandedNodeNames, node.data.name];
-                  }
-                  selected = node;
-                }}
-                class={cls(node.data.children && 'cursor-pointer')}
-              >
-                <Rect
-                  width={nodeWidth}
-                  height={nodeHeight}
-                  class={cls(
-                    'fill-surface-100',
-                    node.data.children
-                      ? 'stroke-primary hover:stroke-2'
-                      : 'stroke-secondary [stroke-dasharray:1]'
-                  )}
-                  rx={10}
-                />
-                <Text
-                  value={node.data.name}
-                  x={nodeWidth / 2}
-                  y={nodeHeight / 2}
-                  dy={-2}
-                  textAnchor="middle"
-                  verticalAnchor="middle"
-                  class={cls(
-                    'text-xs pointer-events-none',
-                    node.data.children ? 'fill-primary' : 'fill-secondary'
-                  )}
-                />
-              </Group>
+      <Svg>
+        <Tree let:nodes let:links {orientation} nodeSize={layout === 'node' ? nodeSize : null}>
+          <g class="opacity-20">
+            {#each links as link (getNodeKey(link.source) + '_' + getNodeKey(link.target))}
+              <Link data={link} {orientation} {curve} tweened class="stroke-surface-content" />
             {/each}
-          </Tree>
-        </Transform>
+          </g>
+
+          {#each nodes as node (getNodeKey(node))}
+            <Group
+              x={(orientation === 'horizontal' ? node.y : node.x) - nodeWidth / 2}
+              y={(orientation === 'horizontal' ? node.x : node.y) - nodeHeight / 2}
+              tweened
+              on:click={() => {
+                if (expandedNodeNames.includes(node.data.name)) {
+                  expandedNodeNames = expandedNodeNames.filter((name) => name !== node.data.name);
+                } else {
+                  expandedNodeNames = [...expandedNodeNames, node.data.name];
+                }
+                selected = node;
+
+                // transform.zoomTo({
+                //   x: orientation === 'horizontal' ? selected.y : selected.x,
+                //   y: orientation === 'horizontal' ? selected.x : selected.y,
+                // });
+              }}
+              class={cls(node.data.children && 'cursor-pointer')}
+            >
+              <Rect
+                width={nodeWidth}
+                height={nodeHeight}
+                class={cls(
+                  'fill-surface-100',
+                  node.data.children
+                    ? 'stroke-primary hover:stroke-2'
+                    : 'stroke-secondary [stroke-dasharray:1]'
+                )}
+                rx={10}
+              />
+              <Text
+                value={node.data.name}
+                x={nodeWidth / 2}
+                y={nodeHeight / 2}
+                dy={-2}
+                textAnchor="middle"
+                verticalAnchor="middle"
+                class={cls(
+                  'text-xs pointer-events-none',
+                  node.data.children ? 'fill-primary' : 'fill-secondary'
+                )}
+              />
+            </Group>
+          {/each}
+        </Tree>
       </Svg>
     </Chart>
   </div>

--- a/packages/layerchart/src/routes/docs/examples/ZoomableMap/+page.svelte
+++ b/packages/layerchart/src/routes/docs/examples/ZoomableMap/+page.svelte
@@ -150,6 +150,7 @@
       </Canvas>
 
       <Canvas>
+        <!-- TODO: Fade in with delay like SVG -->
         <!-- <g in:fade={{ duration: 300, delay: 600 }} out:fade={{ duration: 300 }}> -->
         <GeoPath
           geojson={{ type: 'FeatureCollection', features: selectedCountiesFeatures }}
@@ -180,24 +181,24 @@
         on:pointermove={(e) => tooltip.show(e.detail.event, e.detail.data)}
         on:pointerleave={tooltip.hide}
         on:click={(e) => {
-          // console.log(e.detail.data);
           const feature = e.detail.data;
           const geoPath = d3geoPath(projection);
 
-          // const { geoPath, event } = e.detail;
-          let [[left, top], [right, bottom]] = geoPath.bounds(feature);
-          if (selectedStateId === feature.id) {
+          if (
+            selectedStateId === feature.id ||
+            !states.features.some((f) => f.id == feature.id) // County selected
+          ) {
             selectedStateId = null;
             transform.reset();
           } else {
             selectedStateId = feature.id;
+            let [[left, top], [right, bottom]] = geoPath.bounds(feature);
             let width = right - left;
             let height = bottom - top;
             let x = (left + right) / 2;
             let y = (top + bottom) / 2;
             const padding = 20;
 
-            // console.log({ x, y, width, height });
             transform.zoomTo({ x, y }, { width: width + padding, height: height + padding });
           }
         }}
@@ -205,6 +206,18 @@
         <GeoPath
           render={(ctx, { geoPath }) => {
             for (var feature of states.features) {
+              const color = nextColor();
+
+              ctx.beginPath();
+              geoPath(feature);
+              ctx.fillStyle = color;
+              ctx.fill();
+
+              setColorData(color, feature);
+            }
+
+            // Draw county features on top if state selected
+            for (var feature of selectedCountiesFeatures) {
               const color = nextColor();
 
               ctx.beginPath();

--- a/packages/layerchart/src/routes/docs/examples/ZoomableMap/+page.svelte
+++ b/packages/layerchart/src/routes/docs/examples/ZoomableMap/+page.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import { fade } from 'svelte/transition';
   import { cubicOut } from 'svelte/easing';
-  import { geoAlbersUsa, geoAlbers, geoMercator } from 'd3-geo';
+  import { geoAlbersUsa, geoAlbers, geoMercator, geoPath as d3geoPath } from 'd3-geo';
   import { feature } from 'topojson-client';
 
   import { Field, SelectField, ToggleGroup, ToggleOption } from 'svelte-ux';
@@ -9,10 +9,10 @@
   import Preview from '$lib/docs/Preview.svelte';
   import TransformControls from '$lib/docs/TransformControls.svelte';
 
-  import Chart, { Svg } from '$lib/components/Chart.svelte';
+  import Chart, { Svg, Canvas } from '$lib/components/Chart.svelte';
   import GeoPath from '$lib/components/GeoPath.svelte';
+  import HitCanvas from '$lib/components/HitCanvas.svelte';
   import Tooltip from '$lib/components/Tooltip.svelte';
-  import Transform from '$lib/components/Transform.svelte';
 
   export let data;
 
@@ -26,17 +26,12 @@
   const counties = feature(data.geojson, data.geojson.objects.counties);
   const states = feature(data.geojson, data.geojson.objects.states);
 
-  function filterNonStates(features) {
-    return features.filter((x) => Number(x.id) < 60);
-  }
-
   let selectedStateId = null;
   $: selectedCountiesFeatures = selectedStateId
     ? counties.features.filter((f) => f.id.slice(0, 2) === selectedStateId)
     : [];
 
-  let transform: Transform;
-  let scrollMode = 'scale';
+  let scrollMode = 'none';
 </script>
 
 <div class="grid grid-cols-[1fr,1fr,1fr,auto,auto] gap-2 my-2">
@@ -63,7 +58,6 @@
 
 <Preview data={states}>
   <div class="h-[600px] relative overflow-hidden">
-    <TransformControls {transform} />
     <Chart
       geo={{
         projection,
@@ -71,57 +65,159 @@
       }}
       tooltip={{ mode: 'manual' }}
       let:tooltip
+      transform={{
+        mode: 'canvas',
+        scroll: scrollMode,
+        tweened: { duration: 800, easing: cubicOut },
+      }}
+      let:transform
     >
+      <TransformControls />
+
       <Svg>
-        <Transform
-          bind:this={transform}
-          scroll={scrollMode}
-          tweened={{ duration: 800, easing: cubicOut }}
-          let:zoomTo
-          let:reset={resetZoom}
-          let:scale
-        >
-          {#each filterNonStates(states.features) as feature}
+        {#each states.features as feature}
+          <GeoPath
+            geojson={feature}
+            class="stroke-surface-content fill-surface-100 hover:fill-surface-content/10"
+            strokeWidth={1 / transform.scale}
+            {tooltip}
+            on:click={(e) => {
+              const { geoPath, event } = e.detail;
+              let [[left, top], [right, bottom]] = geoPath.bounds(feature);
+              if (selectedStateId === feature.id) {
+                selectedStateId = null;
+                transform.reset();
+              } else {
+                selectedStateId = feature.id;
+                let width = right - left;
+                let height = bottom - top;
+                let x = (left + right) / 2;
+                let y = (top + bottom) / 2;
+                const padding = 20;
+                transform.zoomTo({ x, y }, { width: width + padding, height: height + padding });
+              }
+            }}
+          />
+        {/each}
+
+        {#each selectedCountiesFeatures as feature (feature.id)}
+          <g in:fade={{ duration: 300, delay: 600 }} out:fade={{ duration: 300 }}>
             <GeoPath
               geojson={feature}
-              class="stroke-surface-content fill-surface-100 hover:fill-surface-content/10"
-              stroke-width={1 / scale}
               {tooltip}
-              on:click={(e) => {
-                const { geoPath, event } = e.detail;
-                let [[left, top], [right, bottom]] = geoPath.bounds(feature);
-                if (selectedStateId === feature.id) {
-                  selectedStateId = null;
-                  resetZoom();
-                } else {
-                  selectedStateId = feature.id;
-                  let width = right - left;
-                  let height = bottom - top;
-                  let x = (left + right) / 2;
-                  let y = (top + bottom) / 2;
-                  const padding = 20;
-                  zoomTo({ x, y }, { width: width + padding, height: height + padding });
-                }
+              strokeWidth={1 / transform.scale}
+              class="stroke-surface-content/10 hover:fill-surface-content/10"
+              on:click={() => {
+                selectedStateId = null;
+                transform.reset();
               }}
             />
-          {/each}
-
-          {#each selectedCountiesFeatures as feature (feature.id)}
-            <g in:fade={{ duration: 300, delay: 600 }} out:fade={{ duration: 300 }}>
-              <GeoPath
-                geojson={feature}
-                {tooltip}
-                stroke-width={1 / scale}
-                class="stroke-surface-content/10 hover:fill-surface-content/10"
-                on:click={() => {
-                  selectedStateId = null;
-                  resetZoom();
-                }}
-              />
-            </g>
-          {/each}
-        </Transform>
+          </g>
+        {/each}
       </Svg>
+      <Tooltip header={(data) => data.properties.name} />
+    </Chart>
+  </div>
+</Preview>
+
+<h2>Canvas</h2>
+
+<Preview data={states}>
+  <div class="h-[600px] relative overflow-hidden">
+    <Chart
+      geo={{
+        projection,
+        fitGeojson: states,
+      }}
+      transform={{
+        mode: 'canvas',
+        scroll: scrollMode,
+        tweened: { duration: 800, easing: cubicOut },
+      }}
+      let:projection
+      tooltip={{ mode: 'manual' }}
+      let:tooltip
+      let:transform
+    >
+      <TransformControls />
+
+      <Canvas>
+        <GeoPath
+          geojson={states}
+          class="stroke-surface-content fill-surface-100 hover:fill-surface-content/10"
+          strokeWidth={1 / transform.scale}
+        />
+      </Canvas>
+
+      <Canvas>
+        <!-- <g in:fade={{ duration: 300, delay: 600 }} out:fade={{ duration: 300 }}> -->
+        <GeoPath
+          geojson={{ type: 'FeatureCollection', features: selectedCountiesFeatures }}
+          {tooltip}
+          strokeWidth={1 / transform.scale}
+          class="stroke-surface-content/10 hover:fill-surface-content/10"
+          on:click={() => {
+            selectedStateId = null;
+            transform.reset();
+          }}
+        />
+        <!-- </g> -->
+      </Canvas>
+
+      {#if tooltip.data}
+        <Canvas>
+          <GeoPath
+            geojson={tooltip.data}
+            strokeWidth={1 / transform.scale}
+            class="stroke-surface-content fill-surface-content/20"
+          />
+        </Canvas>
+      {/if}
+
+      <HitCanvas
+        let:nextColor
+        let:setColorData
+        on:pointermove={(e) => tooltip.show(e.detail.event, e.detail.data)}
+        on:pointerleave={tooltip.hide}
+        on:click={(e) => {
+          // console.log(e.detail.data);
+          const feature = e.detail.data;
+          const geoPath = d3geoPath(projection);
+
+          // const { geoPath, event } = e.detail;
+          let [[left, top], [right, bottom]] = geoPath.bounds(feature);
+          if (selectedStateId === feature.id) {
+            selectedStateId = null;
+            transform.reset();
+          } else {
+            selectedStateId = feature.id;
+            let width = right - left;
+            let height = bottom - top;
+            let x = (left + right) / 2;
+            let y = (top + bottom) / 2;
+            const padding = 20;
+
+            // console.log({ x, y, width, height });
+            transform.zoomTo({ x, y }, { width: width + padding, height: height + padding });
+          }
+        }}
+      >
+        <GeoPath
+          render={(ctx, { geoPath }) => {
+            for (var feature of states.features) {
+              const color = nextColor();
+
+              ctx.beginPath();
+              geoPath(feature);
+              ctx.fillStyle = color;
+              ctx.fill();
+
+              setColorData(color, feature);
+            }
+          }}
+        />
+      </HitCanvas>
+
       <Tooltip header={(data) => data.properties.name} />
     </Chart>
   </div>

--- a/packages/layerchart/src/routes/docs/examples/ZoomableTileMap/+page.svelte
+++ b/packages/layerchart/src/routes/docs/examples/ZoomableTileMap/+page.svelte
@@ -69,7 +69,6 @@
         applyTransform: ['translate', 'scale'],
       }}
       transform={{
-        mode: 'manual',
         initialScale,
         initialTranslate: { x: initialTranslate[0], y: initialTranslate[1] },
         translateOnScale: true,

--- a/packages/layerchart/src/routes/docs/examples/ZoomableTileMap/+page.svelte
+++ b/packages/layerchart/src/routes/docs/examples/ZoomableTileMap/+page.svelte
@@ -15,8 +15,6 @@
   import GeoTile from '$lib/components/GeoTile.svelte';
   import Tooltip from '$lib/components/Tooltip.svelte';
   import TooltipItem from '$lib/components/TooltipItem.svelte';
-  import TransformContext from '$lib/components/TransformContext.svelte';
-  import { tweened } from 'svelte/motion';
 
   export let data;
   const states = feature(data.geojson, data.geojson.objects.states);
@@ -37,9 +35,7 @@
   let scrollMode = 'scale';
   let debug = false;
 
-  let scale = 0;
-  let translate = { x: 480, y: 300 };
-
+  // Needed for initial transform context
   const initialScale = geoMercator().scale();
   const initialTranslate = geoMercator().translate();
 </script>
@@ -70,8 +66,6 @@
       geo={{
         projection: geoMercator,
         _fitGeojson: selectedFeature,
-        // scale,
-        // translate: [translate.x, translate.y],
         applyTransform: ['translate', 'scale'],
       }}
       transform={{
@@ -90,24 +84,6 @@
         <GeoDebug class="absolute top-0 left-0 z-10" />
       {/if}
       <Svg>
-        <!-- <Transform
-          mode="manual"
-          translateOnScale
-          initialScale={projection.scale()}
-          initialTranslate={{
-            x: projection.translate()[0],
-            y: projection.translate()[1],
-          }}
-          scroll={scrollMode}
-          tweened={{ duration: 800, easing: cubicOut }}
-          let:zoomTo
-          let:reset={resetZoom}
-          on:transform={(e) => {
-            scale = e.detail.scale;
-            translate = e.detail.translate;
-          }}
-          bind:this={transform}
-        > -->
         <GeoTile url={serviceUrl} {zoomDelta} {debug} />
         {#each filteredStates.features as feature}
           <GeoPath
@@ -142,7 +118,6 @@
             }}
           />
         {/each}
-        <!-- </Transform> -->
       </Svg>
       <Tooltip header={(data) => data.properties.name} let:data>
         {@const [longitude, latitude] = projection.invert([tooltip.x, tooltip.y])}

--- a/packages/layerchart/src/routes/docs/examples/ZoomableTileMap/+page.svelte
+++ b/packages/layerchart/src/routes/docs/examples/ZoomableTileMap/+page.svelte
@@ -15,7 +15,7 @@
   import GeoTile from '$lib/components/GeoTile.svelte';
   import Tooltip from '$lib/components/Tooltip.svelte';
   import TooltipItem from '$lib/components/TooltipItem.svelte';
-  import Transform from '$lib/components/Transform.svelte';
+  import TransformContext from '$lib/components/TransformContext.svelte';
   import { tweened } from 'svelte/motion';
 
   export let data;


### PR DESCRIPTION
Add new Canvas component (derived from LayerCake) which handles `scaleCanvas()` globally and supports scale/translate transforms

[GeoPath] Respect `strokeWidth` prop within Svg context (not just `stroke-width` attribute) to align with Canvas context usage

Integrate `Transform` into `Chart` (<Chart transform={...} let:transform>) and expose as `transformContext()`. Renamed to `TransformContext` and removed direct SVG control (now handled by `Svg` and `Canvas` components)
