### PR TITLE
[Bar] Add `rounded` prop to round single side (or corner) using path

### DIFF
--- a/.changeset/beige-shrimps-rescue.md
+++ b/.changeset/beige-shrimps-rescue.md
@@ -1,0 +1,5 @@
+---
+"layerchart": patch
+---
+
+[Bar] Add `rounded` prop to round single side (or corner) using path

--- a/packages/layerchart/src/lib/components/Bar.svelte
+++ b/packages/layerchart/src/lib/components/Bar.svelte
@@ -3,6 +3,7 @@
 
   import { createDimensionGetter } from '$lib/utils/rect.js';
   import Rect from './Rect.svelte';
+  import Spline from './Spline.svelte';
 
   const { x: xContext, y: yContext } = getContext('LayerCake');
 
@@ -22,6 +23,18 @@
   export let stroke = 'black';
   export let strokeWidth = 0;
   export let radius = 0;
+
+  /** Control which corners are rounded with radius.  Uses <path> instead of <rect> when not set to `all` */
+  export let rounded:
+    | 'all'
+    | 'top'
+    | 'bottom'
+    | 'left'
+    | 'right'
+    | 'top-left'
+    | 'top-right'
+    | 'bottom-left'
+    | 'bottom-right' = 'all';
 
   export let inset = 0;
   export let groupBy: string | undefined = undefined;
@@ -44,16 +57,50 @@
     },
   });
   $: dimensions = $getDimensions(bar);
+
+  $: topLeft = ['all', 'top', 'left', 'top-left'].includes(rounded);
+  $: topRight = ['all', 'top', 'right', 'top-right'].includes(rounded);
+  $: bottomLeft = ['all', 'bottom', 'left', 'bottom-left'].includes(rounded);
+  $: bottomRight = ['all', 'bottom', 'right', 'bottom-right'].includes(rounded);
+
+  $: width = dimensions.width;
+  $: height = dimensions.height;
+  $: diameter = 2 * radius;
+
+  $: pathData = `M${dimensions.x + radius},${dimensions.y} h${width - diameter}
+      ${topRight ? `a${radius},${radius} 0 0 1 ${radius},${radius}` : `h${radius}v${radius}`}
+      v${height - diameter}
+      ${bottomRight ? `a${radius},${radius} 0 0 1 ${-radius},${radius}` : `v${radius}h${-radius}`}
+      h${diameter - width}
+      ${bottomLeft ? `a${radius},${radius} 0 0 1 ${-radius},${-radius}` : `h${-radius}v${-radius}`}
+      v${diameter - height}
+      ${topLeft ? `a${radius},${radius} 0 0 1 ${radius},${-radius}` : `v${-radius}h${radius}`}
+      z`
+    .split('\n')
+    .join('');
 </script>
 
-<Rect
-  {fill}
-  {spring}
-  {tweened}
-  {stroke}
-  stroke-width={strokeWidth}
-  rx={radius}
-  {...dimensions}
-  {...$$restProps}
-  on:click
-/>
+{#if rounded === 'all'}
+  <Rect
+    {fill}
+    {spring}
+    {tweened}
+    {stroke}
+    stroke-width={strokeWidth}
+    rx={radius}
+    {...dimensions}
+    {...$$restProps}
+    on:click
+  />
+{:else}
+  <Spline
+    {pathData}
+    {fill}
+    {spring}
+    {tweened}
+    {stroke}
+    stroke-width={strokeWidth}
+    {...$$restProps}
+    on:click
+  />
+{/if}

--- a/packages/layerchart/src/routes/docs/examples/Bars/+page.svelte
+++ b/packages/layerchart/src/routes/docs/examples/Bars/+page.svelte
@@ -123,6 +123,32 @@
   </div>
 </Preview>
 
+<h2>Rounded (right-only)</h2>
+
+<Preview {data}>
+  <div class="h-[300px] p-4 border rounded">
+    <Chart
+      {data}
+      x="value"
+      xDomain={[0, null]}
+      xNice
+      y="date"
+      yScale={scaleBand().padding(0.4)}
+      padding={{ left: 20, bottom: 20 }}
+    >
+      <Svg>
+        <Axis placement="bottom" grid rule />
+        <Axis
+          placement="left"
+          format={(d) => formatDate(d, PeriodType.Day, { variant: 'short' })}
+          rule
+        />
+        <Bars radius={4} rounded="right" strokeWidth={1} class="fill-primary" />
+      </Svg>
+    </Chart>
+  </div>
+</Preview>
+
 <h2>Tooltip and Highlight</h2>
 
 <Preview {data}>

--- a/packages/layerchart/src/routes/docs/examples/Columns/+page.svelte
+++ b/packages/layerchart/src/routes/docs/examples/Columns/+page.svelte
@@ -125,6 +125,32 @@
   </div>
 </Preview>
 
+<h2>Rounded (top-only)</h2>
+
+<Preview {data}>
+  <div class="h-[300px] p-4 border rounded">
+    <Chart
+      {data}
+      x="date"
+      xScale={scaleBand().padding(0.4)}
+      y="value"
+      yDomain={[0, null]}
+      yNice={4}
+      padding={{ left: 16, bottom: 24 }}
+    >
+      <Svg>
+        <Axis placement="left" grid rule />
+        <Axis
+          placement="bottom"
+          format={(d) => formatDate(d, PeriodType.Day, { variant: 'short' })}
+          rule
+        />
+        <Bars radius={4} rounded="top" strokeWidth={1} class="fill-primary" />
+      </Svg>
+    </Chart>
+  </div>
+</Preview>
+
 <h2>Tooltip and Highlight</h2>
 
 <Preview {data}>


### PR DESCRIPTION



<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"main","parentHead":"","trunk":"main"}
```
-->
