### PR TITLE
Refactor `ForceSimulation` to allow for more dynamism

### DIFF
--- a/packages/layerchart/src/lib/components/ForceSimulation.svelte
+++ b/packages/layerchart/src/lib/components/ForceSimulation.svelte
@@ -1,67 +1,335 @@
 <script lang="ts">
-  import { getContext } from 'svelte';
+  import { createEventDispatcher, getContext } from 'svelte';
+
   import { forceSimulation, type Force } from 'd3-force';
 
   const { data } = getContext('LayerCake');
 
-  export let forces: Record<string, Force<any, any>>;
+  const dispatch = createEventDispatcher<{
+    start: null;
+    tick: { alpha: number; alphaTarget: number };
+    change: null;
+    end: null;
+  }>();
 
-  export let alpha = 1;
-  export let alphaTarget = 0;
-  export let alphaDecay = 1 - Math.pow(0.001, 1 / 300);
-  export let alphaMin = 0.001;
+  // MARK: Public Props
+
+  type Forces = Record<string, Force<any, any>>;
+  export let forces: Forces;
+
+  export let alpha: number = 1;
+  export let alphaTarget: number = 0;
+  export let alphaDecay: number = 1 - Math.pow(0.001, 1 / 300);
+  export let alphaMin: number = 0.001;
 
   export let velocityDecay = 0.4;
 
-  /** Clone data since simulation mutates original */
-  export let cloneData = false;
+  type AlphaResponse = (alpha: number, alphaTarget: number) => number;
+  export let alphaResponse: AlphaResponse | undefined = undefined;
+
+  export let stopped = false;
 
   let _static = false;
   /** If true, will only update nodes after simulation has completed */
   export { _static as static };
 
-  let simulation = forceSimulation(cloneData ? structuredClone($data) : $data);
+  /** Clone data since simulation mutates original */
+  export const cloneData: boolean = false;
+
+  // MARK: Private Props
+
+  let nodes: any[] = [];
+
+  const simulation = forceSimulation().stop(); //.nodes(nodesFromData());
+
+  // Only dynamic simulations distinguish between paused and running state.
+  // Invariant: Static simulations always keep `paused = true`.
+  let paused: boolean = true;
+
+  // MARK: Reactivity Triggers
 
   $: {
+    // Any time the `stopped` prop gets toggled we
+    // update the running state of the simulation:
+    updateStateOnChangeOf({
+      stopped,
+      _static,
+    });
+  }
+
+  $: {
+    // Any time the `static` prop gets toggled we
+    // either attach or detach our internal event listeners:
+    updateEventListenersOnChangeOf({ _static });
+  }
+
+  $: {
+    // Any time the `$data` store gets changed we
+    // pass them to the internal d3 simulation object:
+    updateNodesOnChangeOf({ data: $data });
+  }
+
+  $: {
+    // Any time the `forces` prop gets changed we
+    // pass them to the internal d3 simulation object:
+    updateForcesOnChangeOf({ forces });
+  }
+
+  $: {
+    // Any time the `alpha` prop gets changed we
+    // pass it to the internal d3 simulation object:
+    updateAlphaOnChangeOf({ alpha });
+  }
+
+  $: {
+    // Any time any of the the alpha props get changed we
+    // pass them all to the internal d3 simulation object
+    // (they are cheap, so passing them as a batch is fine!):
+    updateSettingsOnChangeOf({
+      alphaTarget,
+      alphaMin,
+      alphaDecay,
+      velocityDecay,
+      _static,
+    });
+  }
+
+  // MARK: Reactivity Behaviors
+
+  function updateEventListenersOnChangeOf(args: { _static: boolean }) {
+    const { _static } = args;
+
+    pushEventListenersToSimulation({ _static });
+  }
+
+  function updateStateOnChangeOf(args: { stopped: boolean; _static: boolean }) {
+    const { stopped } = args;
+
+    if (stopped) {
+      if (!_static) {
+        pauseDynamicSimulation();
+      }
+    } else {
+      if (_static) {
+        if (!paused) {
+          pauseDynamicSimulation();
+        }
+        runStaticSimulation();
+      } else {
+        resumeDynamicSimulation();
+      }
+    }
+  }
+
+  function updateAlphaOnChangeOf(args: { alpha: number }) {
+    const { alpha } = args;
+
+    pushAlphaToSimulation({ alpha });
+
+    if (_static) {
+      runStaticSimulation();
+    } else {
+      resumeDynamicSimulation(alpha);
+    }
+  }
+
+  function updateSettingsOnChangeOf(args: {
+    alphaTarget: number;
+    alphaMin: number;
+    alphaDecay: number;
+    velocityDecay: number;
+    _static: boolean;
+  }) {
+    const { alphaTarget, alphaMin, alphaDecay, velocityDecay, _static } = args;
+
+    pushSettingsToSimulation({ alphaTarget, alphaMin, alphaDecay, velocityDecay, _static });
+
+    if (_static) {
+      runStaticSimulation();
+    } else {
+      resumeDynamicSimulation();
+    }
+  }
+
+  function updateNodesOnChangeOf(args: { data: any[] }) {
+    const { data } = args;
+
+    pushNodesToSimulation({ nodes: data });
+
+    if (_static) {
+      runStaticSimulation();
+    } else {
+      resumeDynamicSimulation();
+    }
+  }
+
+  function updateForcesOnChangeOf(args: { forces: Forces }) {
+    const { forces } = args;
+
+    pushForcesToSimulation({ forces });
+
+    if (_static) {
+      runStaticSimulation();
+    } else {
+      resumeDynamicSimulation();
+    }
+  }
+
+  // MARK: Push State
+
+  function pushEventListenersToSimulation(args: { _static: boolean }) {
+    const { _static } = args;
+
+    if (_static) {
+      simulation.on('tick', null).on('end', null);
+    } else {
+      simulation.on('tick', onTick).on('end', onEnd);
+    }
+  }
+
+  function pushSettingsToSimulation(args: {
+    alphaTarget: number;
+    alphaMin: number;
+    alphaDecay: number;
+    velocityDecay: number;
+    _static: boolean;
+  }) {
+    const { alphaTarget, alphaMin, alphaDecay, velocityDecay, _static } = args;
+
+    let alpha = simulation.alpha();
+    if (alphaTarget > alpha && alpha < alphaMin) {
+      // Lift `alpha` from below `alphaMin` in order to give the simulation
+      // a chance to get revived if an `alphaTarget > alpha` is provided:
+      alpha = alphaMin;
+    }
+
     simulation
       .alpha(alpha)
       .alphaTarget(alphaTarget)
       .alphaMin(alphaMin)
       .alphaDecay(alphaDecay)
-      .velocityDecay(velocityDecay)
-      .restart();
+      .velocityDecay(velocityDecay);
+  }
+
+  function pushAlphaToSimulation(args: { alpha: number }) {
+    const { alpha } = args;
+
+    simulation.alpha(alpha);
+  }
+
+  function pushNodesToSimulation(args: { nodes: any[] }) {
+    const { nodes } = args;
+
+    simulation.nodes(cloneData ? structuredClone(nodes) : nodes);
+  }
+
+  function pushForcesToSimulation(args: { forces: Forces }) {
+    const { forces } = args;
+
+    Object.entries(forces).forEach(([name, force]) => {
+      simulation.force(name, force);
+    });
+  }
+
+  // MARK: Pull State
+
+  function pullNodesAndAlphaFromSimulation() {
+    nodes = simulation.nodes();
+    alpha = simulation.alpha();
+  }
+
+  function pullAlphaFromSimulation() {
+    alpha = simulation.alpha();
+  }
+
+  // MARK: Resume / Pause
+
+  function runStaticSimulation() {
+    if (stopped) {
+      return;
+    }
+
+    if (!_static) {
+      return;
+    }
+
+    if (!paused) {
+      // Pause any possibly still running dynamic simulation:
+      pauseDynamicSimulation();
+    }
+
+    const ticks = Math.ceil(
+      Math.log(simulation.alphaMin()) / Math.log(1 - simulation.alphaDecay())
+    );
+
+    pushAlphaToSimulation({ alpha: 1 });
+
+    onStart();
+
+    for (let i = 0; i < ticks; ++i) {
+      simulation.tick();
+      pullAlphaFromSimulation();
+    }
+
+    onEnd();
+  }
+
+  function resumeDynamicSimulation(alpha: number | undefined = undefined) {
+    if (stopped) {
+      return;
+    }
 
     if (_static) {
-      // TODO: Not sure why it needs to be recreated when static
-      simulation = forceSimulation(cloneData ? structuredClone($data) : $data);
-      simulation.stop();
+      return;
+    }
 
-      Object.entries(forces).forEach(([name, force]) => {
-        simulation.force(name, force);
-      });
+    if (alpha) {
+      pushAlphaToSimulation({ alpha });
+    }
 
-      for (
-        let i = 0,
-          n = Math.ceil(Math.log(simulation.alphaMin()) / Math.log(1 - simulation.alphaDecay()));
-        i < n;
-        ++i
-      ) {
-        simulation.tick();
-      }
+    if (paused) {
+      onStart();
+      simulation.restart();
+      paused = false;
 
-      nodes = simulation.nodes();
-    } else {
-      // When variables change, set forces and restart the simulation
-      Object.entries(forces).forEach(([name, force]) => {
-        simulation.force(name, force);
-      });
+      // No need to call `onEnd();` for dynamic simulations
+      // as the simulation itself takes care of firing `on:end`,
+      // which then gets calls `onEnd();` for us.
     }
   }
 
-  let nodes = [];
-  simulation.on('tick', () => {
-    nodes = simulation.nodes();
-  });
+  function pauseDynamicSimulation() {
+    if (!paused) {
+      paused = true;
+      simulation.stop();
+      onEnd();
+    }
+  }
+
+  // MARK: Event Listeners
+
+  function onStart() {
+    dispatch('start');
+  }
+
+  function onTick() {
+    pullNodesAndAlphaFromSimulation();
+
+    dispatch('tick', {
+      alpha,
+      alphaTarget,
+    });
+
+    if (simulation.alpha() < simulation.alphaMin()) {
+      pauseDynamicSimulation();
+    }
+  }
+
+  function onEnd() {
+    pullNodesAndAlphaFromSimulation();
+
+    dispatch('end');
+  }
 </script>
 
 <slot {nodes} {simulation} />

--- a/packages/layerchart/src/routes/docs/examples/Beeswarm/+page.svelte
+++ b/packages/layerchart/src/routes/docs/examples/Beeswarm/+page.svelte
@@ -10,6 +10,10 @@
   export let data;
 
   const genderColor = scaleOrdinal(['hsl(var(--color-info))', 'hsl(var(--color-warning))']);
+
+  const xForce = forceX().strength(0.95);
+  const yForce = forceY().strength(0.075);
+  const collideForce = forceCollide();
 </script>
 
 <h1>Examples</h1>
@@ -30,13 +34,9 @@
         <Axis placement="bottom" format="none" rule grid />
         <ForceSimulation
           forces={{
-            x: forceX()
-              .x((d) => xGet(d))
-              .strength(0.95),
-            y: forceY()
-              .y(height / 2)
-              .strength(0.075),
-            collide: forceCollide(r),
+            x: xForce.x((d) => xGet(d)),
+            y: yForce.y(height / 2),
+            collide: collideForce.radius(r),
           }}
           static
           cloneData

--- a/packages/layerchart/src/routes/docs/examples/ForceDisjointGraph/+page.svelte
+++ b/packages/layerchart/src/routes/docs/examples/ForceDisjointGraph/+page.svelte
@@ -13,6 +13,11 @@
   const { nodes, links } = data.miserables;
 
   const colorScale = scaleOrdinal(schemeCategory10);
+
+  const linkForce = forceLink(links).id((d) => d.id);
+  const chargeForce = forceManyBody();
+  const xForce = forceX();
+  const yForce = forceY();
 </script>
 
 <h1>Examples</h1>
@@ -23,10 +28,10 @@
       <Svg>
         <ForceSimulation
           forces={{
-            link: forceLink(links).id((d) => d.id),
-            charge: forceManyBody(),
-            x: forceX(),
-            y: forceY(),
+            link: linkForce,
+            charge: chargeForce,
+            x: xForce,
+            y: yForce,
           }}
           let:nodes
         >

--- a/packages/layerchart/src/routes/docs/examples/ForceGraph/+page.svelte
+++ b/packages/layerchart/src/routes/docs/examples/ForceGraph/+page.svelte
@@ -46,7 +46,6 @@
     alpha = 1;
 
     // Change the link force without re-initializing any forces:
-    const linkForce = forces.link as ForceLink<any, any>;
     linkForce.distance(linkDistance);
   }
 
@@ -56,7 +55,6 @@
     alpha = 1;
 
     // Change the center force without re-initializing any forces:
-    const centerForce = forces.center as ForceCenter<any>;
     centerForce.strength(centerStrength);
   }
 
@@ -69,7 +67,6 @@
     alpha = 1;
 
     // Change the charge force without re-initializing any forces:
-    const chargeForce = forces.charge as ForceManyBody<any>;
     chargeForce
       .distanceMin(chargeDistanceMin)
       .distanceMax(chargeDistanceMaxInfinity ? Infinity : chargeDistanceMax)
@@ -83,21 +80,18 @@
     alpha = 1;
 
     // Change the collide force without re-initializing any forces:
-    const collideForce = forces.collide as ForceCollide<any>;
     collideForce.radius(collideRadius).strength(collideStrength(collideStrengthTarget));
   }
 
-  let forces: Record<string, Force<any, any>> = {
-    link: forceLink(links)
-      .id((d) => d.id)
-      .distance(linkDistance),
-    charge: forceManyBody()
-      .distanceMin(chargeDistanceMin)
-      .distanceMax(chargeDistanceMaxInfinity ? Infinity : chargeDistanceMax)
-      .strength(chargeStrength),
-    collide: forceCollide(collideRadius).strength(collideStrength(collideStrengthTarget)),
-    center: forceCenter(0, 0).strength(centerStrength),
-  };
+  const linkForce = forceLink(links)
+    .id((d) => d.id)
+    .distance(linkDistance);
+  const chargeForce = forceManyBody()
+    .distanceMin(chargeDistanceMin)
+    .distanceMax(chargeDistanceMaxInfinity ? Infinity : chargeDistanceMax)
+    .strength(chargeStrength);
+  const collideForce = forceCollide(collideRadius).strength(collideStrength(collideStrengthTarget));
+  const centerForce = forceCenter(0, 0).strength(centerStrength);
 
   function handleStart(event: CustomEvent<null>) {
     running = true;
@@ -111,16 +105,6 @@
 
   function handleEnd(event: CustomEvent<null>) {
     running = false;
-  }
-
-  // This function caches its forces object,
-  // (mutating the center force if necessary)
-  // and always returns the same object, thus avoiding needless
-  // force re-initializations by d3-force:
-  function forcesFor(size: { width: number; height: number }): Record<string, Force<any, any>> {
-    const centerForce = forces.center as ForceCenter<any>;
-    centerForce.x(size.width / 2).y(size.height / 2);
-    return forces;
   }
 
   function collideStrength(collideStrengthTarget: number): number {
@@ -246,7 +230,12 @@
     <Chart data={nodes} let:width let:height let:tooltip>
       <Svg>
         <ForceSimulation
-          forces={forcesFor({ width, height })}
+          forces={{
+            link: linkForce,
+            charge: chargeForce,
+            collide: collideForce,
+            center: centerForce.x(width / 2).y(height / 2),
+          }}
           bind:alpha
           bind:alphaTarget
           bind:stopped={isStopped}

--- a/packages/layerchart/src/routes/docs/examples/ForceGraph/+page.svelte
+++ b/packages/layerchart/src/routes/docs/examples/ForceGraph/+page.svelte
@@ -1,18 +1,5 @@
 <script lang="ts">
-  import { onMount } from 'svelte';
-
-  import {
-    forceCollide,
-    forceManyBody,
-    forceLink,
-    forceCenter,
-    type Force,
-    forceSimulation,
-    type ForceCenter,
-    type ForceCollide,
-    type ForceLink,
-    type ForceManyBody,
-  } from 'd3-force';
+  import { forceCollide, forceManyBody, forceLink, forceCenter } from 'd3-force';
   import { curveLinear } from 'd3-shape';
   import { scaleOrdinal } from 'd3-scale';
   import { schemeCategory10 } from 'd3-scale-chromatic';
@@ -28,7 +15,7 @@
 
   const colorScale = scaleOrdinal(schemeCategory10);
 
-  let isStopped: boolean = true;
+  let isStopped: boolean = false;
   let isStatic: boolean = false;
 
   let alpha = 1;
@@ -38,77 +25,75 @@
   let running = false;
 
   let nodeRadius = 3;
+  let nodeStrokeWidth = 0;
   let linkWidth = 1;
+  let linkOpacity = 0.5;
+
+  let hasLinkForce = true;
+  let hasChargeForce = true;
+  let hasCollideForce = true;
+  let hasCenterForce = true;
+  $: {
+    reheatSimulation({
+      hasLinkForce,
+      hasChargeForce,
+      hasCollideForce,
+      hasCenterForce,
+    });
+  }
+
+  const linkForce = forceLink(links).id((d) => d.id);
+  const chargeForce = forceManyBody();
+  const collideForce = forceCollide();
+  const centerForce = forceCenter(0, 0);
 
   let linkDistance = 30;
   $: {
-    // Reheat the simulation:
-    alpha = 1;
-
-    // Change the link force without re-initializing any forces:
+    reheatSimulation();
     linkForce.distance(linkDistance);
   }
 
-  let centerStrength = 1;
-  $: {
-    // Reheat the simulation:
-    alpha = 1;
-
-    // Change the center force without re-initializing any forces:
-    centerForce.strength(centerStrength);
-  }
-
-  let chargeStrength = -30;
   let chargeDistanceMin = 1;
-  let chargeDistanceMax = 100;
-  let chargeDistanceMaxInfinity = true;
+  let chargeDistanceMax = 1000;
+  let chargeStrength = -30;
   $: {
-    // Reheat the simulation:
-    alpha = 1;
-
-    // Change the charge force without re-initializing any forces:
+    reheatSimulation();
     chargeForce
       .distanceMin(chargeDistanceMin)
-      .distanceMax(chargeDistanceMaxInfinity ? Infinity : chargeDistanceMax)
+      .distanceMax(chargeDistanceMax)
       .strength(chargeStrength);
   }
 
   let collideRadius = 3;
-  let collideStrengthTarget = 1;
+  let collideStrength = 1;
   $: {
-    // Reheat the simulation:
-    alpha = 1;
-
-    // Change the collide force without re-initializing any forces:
-    collideForce.radius(collideRadius).strength(collideStrength(collideStrengthTarget));
+    reheatSimulation();
+    collideForce.radius(collideRadius).strength(collideStrength);
   }
 
-  const linkForce = forceLink(links)
-    .id((d) => d.id)
-    .distance(linkDistance);
-  const chargeForce = forceManyBody()
-    .distanceMin(chargeDistanceMin)
-    .distanceMax(chargeDistanceMaxInfinity ? Infinity : chargeDistanceMax)
-    .strength(chargeStrength);
-  const collideForce = forceCollide(collideRadius).strength(collideStrength(collideStrengthTarget));
-  const centerForce = forceCenter(0, 0).strength(centerStrength);
+  let centerStrength = 1.0;
+  $: {
+    reheatSimulation();
+    centerForce.strength(centerStrength);
+  }
 
   function handleStart(event: CustomEvent<null>) {
     running = true;
   }
 
   function handleTick(event: CustomEvent<{ alpha: number; alphaTarget: number }>) {
-    // If we didn't already use `bind:alpha` then this is where we would get access to
-    // the current values of `alpha` and `alphaTarget`, which then would allow us
-    // to dynamically adjust e.g. the forces of our simulation.
+    // If we weren't already using `bind:alpha`, then this is
+    // where we would get access to the current values of
+    // `alpha` and `alphaTarget` and could make adjustments accordingly.
   }
 
   function handleEnd(event: CustomEvent<null>) {
     running = false;
   }
 
-  function collideStrength(collideStrengthTarget: number): number {
-    return (1.0 - alpha) * collideStrengthTarget;
+  function reheatSimulation(args: Record<string, any> = {}) {
+    const _ = args;
+    alpha = 1.0;
   }
 </script>
 
@@ -116,16 +101,11 @@
 
 <div class="grid gap-1 mb-4">
   <div class="grid grid-cols-7 gap-2">
-    <Field label="State" class="col-span-1">
-      <Checkbox size="xs" bind:checked={isStopped}>Stopped</Checkbox>
-    </Field>
-    <Field label="Status" class="col-span-1">
-      {#if running}
-        <ProgressCircle size={15} />
-      {/if}
-    </Field>
     <Field label="Type" class="col-span-1">
       <Checkbox size="xs" bind:checked={isStatic}>Static</Checkbox>
+    </Field>
+    <Field label="State" class="col-span-1">
+      <Checkbox size="xs" bind:checked={isStopped}>Stopped</Checkbox>
     </Field>
     <RangeField
       label="Alpha Target"
@@ -135,8 +115,19 @@
       max={1}
       step={0.1}
     />
-    <Field label="Alpha" class="col-span-2">
-      <Progress value={alpha} />
+    <RangeField
+      label="Alpha"
+      class="col-span-2"
+      bind:value={alpha}
+      min={0}
+      max={1}
+      step={0.001}
+      format="decimal"
+    />
+    <Field label="Running" class="col-span-1">
+      {#if running}
+        <ProgressCircle size={15} />
+      {/if}
     </Field>
   </div>
   <div class="grid grid-cols-4 gap-2">
@@ -149,6 +140,14 @@
       step={1}
     />
     <RangeField
+      label="Node Stroke Width"
+      class="col-span-1"
+      bind:value={nodeStrokeWidth}
+      min={0}
+      max={10}
+      step={0.5}
+    />
+    <RangeField
       label="Link Width"
       class="col-span-1"
       bind:value={linkWidth}
@@ -157,31 +156,43 @@
       step={0.5}
     />
     <RangeField
-      label="Link Distance"
+      label="Link Opacity"
       class="col-span-1"
+      bind:value={linkOpacity}
+      min={0.1}
+      max={1}
+      step={0.1}
+    />
+  </div>
+  <div class="grid grid-cols-7 gap-2">
+    <Field label="Link Force" class="col-span-1">
+      <Checkbox size="xs" bind:checked={hasLinkForce} />
+    </Field>
+    <RangeField
+      label="Link Distance"
+      class="col-span-3"
       bind:value={linkDistance}
       min={0}
       max={100}
       step={1}
+      disabled={!hasCenterForce}
     />
+    <Field label="Center Force" class="col-span-1">
+      <Checkbox size="xs" bind:checked={hasCenterForce} />
+    </Field>
     <RangeField
       label="Center Strength"
-      class="col-span-1"
+      class="col-span-2"
       bind:value={centerStrength}
       min={0}
       max={1}
-      step={0.01}
+      step={0.1}
     />
   </div>
   <div class="grid grid-cols-7 gap-2">
-    <RangeField
-      label="Charge Strength"
-      class="col-span-2"
-      bind:value={chargeStrength}
-      min={-100}
-      max={10}
-      step={1}
-    />
+    <Field label="Charge Force" class="col-span-1">
+      <Checkbox size="xs" bind:checked={hasChargeForce} />
+    </Field>
     <RangeField
       label="Charge Distance Min"
       class="col-span-2"
@@ -189,40 +200,47 @@
       min={1}
       max={10}
       step={1}
+      disabled={!hasChargeForce}
     />
     <RangeField
       label="Charge Distance Max"
       class="col-span-2"
       bind:value={chargeDistanceMax}
       min={1}
-      max={200}
-      step={1}
-      disabled={chargeDistanceMaxInfinity}
+      max={1000}
+      step={10}
+      disabled={!hasChargeForce}
     />
-    <Field label="Charge Distance" class="col-span-1">
-      <Checkbox size="xs" bind:checked={chargeDistanceMaxInfinity}>Infinity</Checkbox>
-    </Field>
+    <RangeField
+      label="Charge Strength"
+      class="col-span-2"
+      bind:value={chargeStrength}
+      min={-100}
+      max={10}
+      step={1}
+      disabled={!hasChargeForce}
+    />
   </div>
-  <div class="grid grid-cols-3 gap-2">
+  <div class="grid grid-cols-7 gap-2">
+    <Field label="Collide Force" class="col-span-1">
+      <Checkbox size="xs" bind:checked={hasCollideForce} />
+    </Field>
     <RangeField
       label="Collide Radius"
-      class="col-span-1"
+      class="col-span-3"
       bind:value={collideRadius}
       min={0}
       max={30}
       step={1}
     />
     <RangeField
-      label="Collide Strength Target"
-      class="col-span-1"
-      bind:value={collideStrengthTarget}
+      label="Collide Strength"
+      class="col-span-3"
+      bind:value={collideStrength}
       min={0}
       max={1}
       step={0.1}
     />
-    <Field label="Collide Strength" class="col-span-1">
-      <Progress value={collideStrength(collideStrengthTarget)} />
-    </Field>
   </div>
 </div>
 <Preview data={data.miserables}>
@@ -231,10 +249,10 @@
       <Svg>
         <ForceSimulation
           forces={{
-            link: linkForce,
-            charge: chargeForce,
-            collide: collideForce,
-            center: centerForce.x(width / 2).y(height / 2),
+            ...(hasLinkForce && { link: linkForce }),
+            ...(hasChargeForce && { charge: chargeForce }),
+            ...(hasCollideForce && { collide: collideForce }),
+            ...(hasCenterForce && { center: centerForce.x(width / 2).y(height / 2) }),
           }}
           bind:alpha
           bind:alphaTarget
@@ -249,9 +267,10 @@
             {#each links as link}
               <Link
                 data={link}
-                class="stroke-surface-content/50"
+                class="stroke-surface-content"
                 curve={curveLinear}
                 stroke-width={linkWidth}
+                opacity={linkOpacity}
               />
             {/each}
           {/key}
@@ -262,6 +281,8 @@
               cy={node.y}
               r={nodeRadius}
               fill={colorScale(node.group)}
+              stroke-width={nodeStrokeWidth}
+              class="stroke-surface-content"
               on:pointermove={(e) => tooltip.show(e, node)}
               on:pointerleave={tooltip.hide}
             />

--- a/packages/layerchart/src/routes/docs/examples/ForceGraph/+page.svelte
+++ b/packages/layerchart/src/routes/docs/examples/ForceGraph/+page.svelte
@@ -1,10 +1,24 @@
 <script lang="ts">
-  import { forceManyBody, forceLink, forceCenter } from 'd3-force';
+  import { onMount } from 'svelte';
+
+  import {
+    forceCollide,
+    forceManyBody,
+    forceLink,
+    forceCenter,
+    type Force,
+    forceSimulation,
+    type ForceCenter,
+    type ForceCollide,
+    type ForceLink,
+    type ForceManyBody,
+  } from 'd3-force';
   import { curveLinear } from 'd3-shape';
   import { scaleOrdinal } from 'd3-scale';
   import { schemeCategory10 } from 'd3-scale-chromatic';
 
   import { Chart, Circle, ForceSimulation, Link, Svg, Tooltip, TooltipItem } from 'layerchart';
+  import { Checkbox, Field, Progress, ProgressCircle, RangeField } from 'svelte-ux';
 
   import Preview from '$lib/docs/Preview.svelte';
 
@@ -13,25 +27,243 @@
   const { nodes, links } = data.miserables;
 
   const colorScale = scaleOrdinal(schemeCategory10);
+
+  let isStopped: boolean = true;
+  let isStatic: boolean = false;
+
+  let alpha = 1;
+  $: console.log('alpha', alpha);
+
+  let alphaTarget = 0;
+  let running = false;
+
+  let nodeRadius = 3;
+  let linkWidth = 1;
+
+  let linkDistance = 30;
+  $: {
+    // Reheat the simulation:
+    alpha = 1;
+
+    // Change the link force without re-initializing any forces:
+    const linkForce = forces.link as ForceLink<any, any>;
+    linkForce.distance(linkDistance);
+  }
+
+  let centerStrength = 1;
+  $: {
+    // Reheat the simulation:
+    alpha = 1;
+
+    // Change the center force without re-initializing any forces:
+    const centerForce = forces.center as ForceCenter<any>;
+    centerForce.strength(centerStrength);
+  }
+
+  let chargeStrength = -30;
+  let chargeDistanceMin = 1;
+  let chargeDistanceMax = 100;
+  let chargeDistanceMaxInfinity = true;
+  $: {
+    // Reheat the simulation:
+    alpha = 1;
+
+    // Change the charge force without re-initializing any forces:
+    const chargeForce = forces.charge as ForceManyBody<any>;
+    chargeForce
+      .distanceMin(chargeDistanceMin)
+      .distanceMax(chargeDistanceMaxInfinity ? Infinity : chargeDistanceMax)
+      .strength(chargeStrength);
+  }
+
+  let collideRadius = 3;
+  let collideStrengthTarget = 1;
+  $: {
+    // Reheat the simulation:
+    alpha = 1;
+
+    // Change the collide force without re-initializing any forces:
+    const collideForce = forces.collide as ForceCollide<any>;
+    collideForce.radius(collideRadius).strength(collideStrength(collideStrengthTarget));
+  }
+
+  let forces: Record<string, Force<any, any>> = {
+    link: forceLink(links)
+      .id((d) => d.id)
+      .distance(linkDistance),
+    charge: forceManyBody()
+      .distanceMin(chargeDistanceMin)
+      .distanceMax(chargeDistanceMaxInfinity ? Infinity : chargeDistanceMax)
+      .strength(chargeStrength),
+    collide: forceCollide(collideRadius).strength(collideStrength(collideStrengthTarget)),
+    center: forceCenter(0, 0).strength(centerStrength),
+  };
+
+  function handleStart(event: CustomEvent<null>) {
+    running = true;
+  }
+
+  function handleTick(event: CustomEvent<{ alpha: number; alphaTarget: number }>) {
+    // If we didn't already use `bind:alpha` then this is where we would get access to
+    // the current values of `alpha` and `alphaTarget`, which then would allow us
+    // to dynamically adjust e.g. the forces of our simulation.
+  }
+
+  function handleEnd(event: CustomEvent<null>) {
+    running = false;
+  }
+
+  // This function caches its forces object,
+  // (mutating the center force if necessary)
+  // and always returns the same object, thus avoiding needless
+  // force re-initializations by d3-force:
+  function forcesFor(size: { width: number; height: number }): Record<string, Force<any, any>> {
+    const centerForce = forces.center as ForceCenter<any>;
+    centerForce.x(size.width / 2).y(size.height / 2);
+    return forces;
+  }
+
+  function collideStrength(collideStrengthTarget: number): number {
+    return (1.0 - alpha) * collideStrengthTarget;
+  }
 </script>
 
 <h1>Examples</h1>
 
+<div class="grid gap-1 mb-4">
+  <div class="grid grid-cols-7 gap-2">
+    <Field label="State" class="col-span-1">
+      <Checkbox size="xs" bind:checked={isStopped}>Stopped</Checkbox>
+    </Field>
+    <Field label="Status" class="col-span-1">
+      {#if running}
+        <ProgressCircle size={15} />
+      {/if}
+    </Field>
+    <Field label="Type" class="col-span-1">
+      <Checkbox size="xs" bind:checked={isStatic}>Static</Checkbox>
+    </Field>
+    <RangeField
+      label="Alpha Target"
+      class="col-span-2"
+      bind:value={alphaTarget}
+      min={0}
+      max={1}
+      step={0.1}
+    />
+    <Field label="Alpha" class="col-span-2">
+      <Progress value={alpha} />
+    </Field>
+  </div>
+  <div class="grid grid-cols-4 gap-2">
+    <RangeField
+      label="Node Radius"
+      class="col-span-1"
+      bind:value={nodeRadius}
+      min={3}
+      max={30}
+      step={1}
+    />
+    <RangeField
+      label="Link Width"
+      class="col-span-1"
+      bind:value={linkWidth}
+      min={1}
+      max={10}
+      step={0.5}
+    />
+    <RangeField
+      label="Link Distance"
+      class="col-span-1"
+      bind:value={linkDistance}
+      min={0}
+      max={100}
+      step={1}
+    />
+    <RangeField
+      label="Center Strength"
+      class="col-span-1"
+      bind:value={centerStrength}
+      min={0}
+      max={1}
+      step={0.01}
+    />
+  </div>
+  <div class="grid grid-cols-7 gap-2">
+    <RangeField
+      label="Charge Strength"
+      class="col-span-2"
+      bind:value={chargeStrength}
+      min={-100}
+      max={10}
+      step={1}
+    />
+    <RangeField
+      label="Charge Distance Min"
+      class="col-span-2"
+      bind:value={chargeDistanceMin}
+      min={1}
+      max={10}
+      step={1}
+    />
+    <RangeField
+      label="Charge Distance Max"
+      class="col-span-2"
+      bind:value={chargeDistanceMax}
+      min={1}
+      max={200}
+      step={1}
+      disabled={chargeDistanceMaxInfinity}
+    />
+    <Field label="Charge Distance" class="col-span-1">
+      <Checkbox size="xs" bind:checked={chargeDistanceMaxInfinity}>Infinity</Checkbox>
+    </Field>
+  </div>
+  <div class="grid grid-cols-3 gap-2">
+    <RangeField
+      label="Collide Radius"
+      class="col-span-1"
+      bind:value={collideRadius}
+      min={0}
+      max={30}
+      step={1}
+    />
+    <RangeField
+      label="Collide Strength Target"
+      class="col-span-1"
+      bind:value={collideStrengthTarget}
+      min={0}
+      max={1}
+      step={0.1}
+    />
+    <Field label="Collide Strength" class="col-span-1">
+      <Progress value={collideStrength(collideStrengthTarget)} />
+    </Field>
+  </div>
+</div>
 <Preview data={data.miserables}>
   <div class="h-[600px] p-4 border rounded">
     <Chart data={nodes} let:width let:height let:tooltip>
       <Svg>
         <ForceSimulation
-          forces={{
-            link: forceLink(links).id((d) => d.id),
-            charge: forceManyBody(),
-            center: forceCenter(width / 2, height / 2),
-          }}
+          forces={forcesFor({ width, height })}
+          bind:alpha
+          bind:alphaTarget
+          bind:stopped={isStopped}
+          bind:static={isStatic}
+          on:start={handleStart}
+          on:tick={handleTick}
+          on:end={handleEnd}
           let:nodes
         >
           {#key nodes}
             {#each links as link}
-              <Link data={link} class="stroke-surface-content/50" curve={curveLinear} />
+              <Link
+                data={link}
+                class="stroke-surface-content/50"
+                curve={curveLinear}
+                stroke-width={linkWidth}
+              />
             {/each}
           {/key}
 
@@ -39,7 +271,7 @@
             <Circle
               cx={node.x}
               cy={node.y}
-              r={3}
+              r={nodeRadius}
               fill={colorScale(node.group)}
               on:pointermove={(e) => tooltip.show(e, node)}
               on:pointerleave={tooltip.hide}

--- a/packages/layerchart/src/routes/docs/examples/ForceGraph/+page.svelte
+++ b/packages/layerchart/src/routes/docs/examples/ForceGraph/+page.svelte
@@ -19,7 +19,6 @@
   let isStatic: boolean = false;
 
   let alpha = 1;
-  $: console.log('alpha', alpha);
 
   let alphaTarget = 0;
   let running = false;

--- a/packages/layerchart/src/routes/docs/examples/ForceGroup/+page.svelte
+++ b/packages/layerchart/src/routes/docs/examples/ForceGroup/+page.svelte
@@ -16,6 +16,19 @@
   ]);
 
   let groupBy = true;
+  $: reheatSimulation({ groupBy });
+
+  let alpha = 1;
+
+  const xForce = forceX().strength(0.1);
+  const chargeForce = forceManyBody().strength(3);
+  const collideForce = forceCollide();
+  const centerForce = forceCenter();
+
+  function reheatSimulation(args: Record<string, any> = {}) {
+    const _ = args;
+    alpha = 1.0;
+  }
 </script>
 
 <h1>Examples</h1>
@@ -48,16 +61,15 @@
       <Svg>
         <ForceSimulation
           forces={{
-            x: forceX()
-              .x((d) => (groupBy ? xGet(d) + xScale.bandwidth() / 2 : width / 2))
-              .strength(0.1),
-            charge: forceManyBody().strength(3),
-            collision: forceCollide().radius(
+            x: xForce.x((d) => (groupBy ? xGet(d) + xScale.bandwidth() / 2 : width / 2)),
+            charge: chargeForce,
+            collide: collideForce.radius(
               (d) => rGet(d) + nodeStrokeWidth / 2 // Divide this by two because an svg stroke is drawn halfway out
             ),
-            center: forceCenter(width / 2, height / 2),
+            center: centerForce.x(width / 2).y(height / 2),
           }}
           cloneData
+          bind:alpha
           let:nodes
         >
           {#each nodes as node}

--- a/packages/layerchart/src/routes/docs/examples/ForceLattice/+page.svelte
+++ b/packages/layerchart/src/routes/docs/examples/ForceLattice/+page.svelte
@@ -16,6 +16,9 @@
     }
   }
   const data = { nodes: nodes, links: links };
+
+  const chargeForce = forceManyBody().strength(-20);
+  const linkForce = forceLink(links).strength(1).distance(20).iterations(10);
 </script>
 
 <h1>Examples</h1>
@@ -26,8 +29,8 @@
       <Svg>
         <ForceSimulation
           forces={{
-            charge: forceManyBody().strength(-20),
-            link: forceLink(links).strength(1).distance(20).iterations(10),
+            charge: chargeForce,
+            link: linkForce,
           }}
           let:nodes
         >

--- a/packages/layerchart/src/routes/docs/examples/ForceTree/+page.svelte
+++ b/packages/layerchart/src/routes/docs/examples/ForceTree/+page.svelte
@@ -21,6 +21,11 @@
   const root = hierarchy(data.flare);
   const nodes = root.descendants();
   const links = root.links();
+
+  const linkForce = forceLink(links).distance(0).strength(1);
+  const chargeForce = forceManyBody().strength(-50);
+  const xForce = forceX();
+  const yForce = forceY();
 </script>
 
 <h1>Examples</h1>
@@ -31,10 +36,10 @@
       <Svg>
         <ForceSimulation
           forces={{
-            link: forceLink(links).distance(0).strength(1),
-            charge: forceManyBody().strength(-50),
-            x: forceX(),
-            y: forceY(),
+            link: linkForce,
+            charge: chargeForce,
+            x: xForce,
+            y: yForce,
           }}
           let:nodes
         >


### PR DESCRIPTION
This admittedly major refactor of `ForceSimulation` resolves #198, #202, #203 and #204, while adding support for highly dynamic, yet efficient simulations.

### Changes

- Exports `cloneData` as `const` (rather than `let`)
  (resolves #203)
- Updates `alpha` prop based on internal d3 simulation (important: dynamic sims now need reheating!)
  (resolves #202)

### Improvements

- No longer re-initializes forces on unrelated prop-changes
  (resolves #204)
- No longer re-initializes all forces if any of them changes
  (resolves #201)
- No longer rebuilds internal `d3.Simulation` for `static=true` on every frame

### Bug Fixes

- Automatically evicts dropped forces
  (resolves #206)

### New features

- Exports `start`, `tick` and `end` events
  (resolves #198)
- Exports `stopped` prop for pausing simulation

### Example changes

- Adds all sorts of controls to "Force Graph" example for simulation forces and parameters