### PR TITLE
[Highlight] Support stack data showing individual points and with correct color

### DIFF
--- a/.changeset/dry-mugs-nail.md
+++ b/.changeset/dry-mugs-nail.md
@@ -1,0 +1,5 @@
+---
+'layerchart': patch
+---
+
+[Highlight] Support stack data showing individual points and with correct color

--- a/packages/layerchart/src/routes/docs/examples/AreaStack/+page.svelte
+++ b/packages/layerchart/src/routes/docs/examples/AreaStack/+page.svelte
@@ -11,6 +11,7 @@
     Axis,
     Chart,
     Highlight,
+    Labels,
     LinearGradient,
     Svg,
     Tooltip,
@@ -94,6 +95,38 @@
     </Chart>
   </div>
 </Preview>
+
+<!-- TODO: Current shows the stacked value, but should it show the individual series value instead? -->
+<!-- <h2>With Labels</h2>
+
+<Preview data={stackData}>
+  <div class="h-[300px] p-4 border rounded">
+    <Chart
+      data={stackData}
+      flatData={flatten(stackData)}
+      x={(d) => d.data.date}
+      xScale={scaleTime()}
+      y={[0, 1]}
+      yNice
+      r="key"
+      rScale={scaleOrdinal()}
+      rDomain={keys}
+      rRange={['hsl(var(--color-danger))', 'hsl(var(--color-success))', 'hsl(var(--color-info))']}
+      padding={{ left: 16, bottom: 24 }}
+    >
+      <Svg>
+        <Axis placement="left" grid rule />
+        <Axis
+          placement="bottom"
+          format={(d) => formatDate(d, PeriodType.Day, { variant: 'short' })}
+          rule
+        />
+        <AreaStack line={{ 'stroke-width': 2 }} />
+        <Labels />
+      </Svg>
+    </Chart>
+  </div>
+</Preview> -->
 
 <h2>Slot with gradient</h2>
 


### PR DESCRIPTION
## Before

https://github.com/techniq/layerchart/assets/177476/4df0d2cb-bdbf-4edd-ab44-9e09fc2989d8



## After


https://github.com/techniq/layerchart/assets/177476/1b475765-2e5b-400e-a06c-bce8b5e860fd




<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"main","parentHead":"","trunk":"main"}
```
-->
