### PR TITLE
[Highlight] Support non-stack array accessor when displaying points

### DIFF
--- a/.changeset/tricky-cats-cheer.md
+++ b/.changeset/tricky-cats-cheer.md
@@ -1,0 +1,5 @@
+---
+'layerchart': patch
+---
+
+[Highlight] Support non-stack array accessor when displaying points

--- a/packages/layerchart/src/routes/docs/examples/Area/+page.svelte
+++ b/packages/layerchart/src/routes/docs/examples/Area/+page.svelte
@@ -259,6 +259,10 @@
       y={['apples', 'bananas', 'oranges']}
       yDomain={[0, null]}
       yNice
+      r={(d) => d.$key}
+      rScale={scaleOrdinal()}
+      rDomain={Object.keys(fruitColors)}
+      rRange={Object.values(fruitColors)}
       padding={{ left: 16, bottom: 24, right: 48 }}
       tooltip={{ mode: 'bisect-x' }}
     >
@@ -291,8 +295,7 @@
           fill-opacity={0.3}
           line={{ stroke: fruitColors.oranges, class: 'stroke-2' }}
         />
-        <!-- TODO: Fix points with y array -->
-        <Highlight lines />
+        <Highlight lines points />
       </Svg>
       <Tooltip header={(data) => formatDate(data.date, 'eee, MMMM do')} let:data>
         <TooltipItem label="apples" value={data.apples} />


### PR DESCRIPTION
## Before

https://github.com/techniq/layerchart/assets/177476/37356f1d-5b8d-411d-8625-7892f32583ea 

## After

https://github.com/techniq/layerchart/assets/177476/d1bc5890-bf8f-452f-92e2-d390390f006f



<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"main","parentHead":"","trunk":"main"}
```
-->
