### PR TITLE
Spline: Add `$$props.fill` guard around 'fill-none'

### DIFF
--- a/.changeset/tender-pianos-yell.md
+++ b/.changeset/tender-pianos-yell.md
@@ -1,0 +1,5 @@
+---
+'layerchart': patch
+---
+
+[Spline] Add `$$props.fill` guard to allow `fill` to work on Spline paths

--- a/packages/layerchart/src/lib/components/Spline.svelte
+++ b/packages/layerchart/src/lib/components/Spline.svelte
@@ -133,7 +133,7 @@
   <path
     d={$tweened_d}
     {...$$restProps}
-    class={cls('path-line fill-none', !$$props.stroke && 'stroke-surface-content', $$props.class)}
+    class={cls('path-line', !$$props.fill && 'fill-none', !$$props.stroke && 'stroke-surface-content', $$props.class)}
     in:drawTransition|global={typeof draw === 'object' ? draw : undefined}
     on:click
     on:pointermove


### PR DESCRIPTION
Hey, great work on this library, looking forward to hopefully seeing it be integrated into shadcn-svelte's Charts!

I've been using the bar charts and observed that stacked/grouped Bar components do not render with a fill from the chart `rRange` when the rounded prop is set to anything except 'all'. This can be seen below where I've set `rounded="top"`:
![image](https://github.com/user-attachments/assets/ceda5788-f420-41d9-bba1-13e77f266d67)

I've identified that this is caused by the `fill-none` class on `Spline.svelte`'s path element taking precedence over the passed `fill` attribute. Passing a fill class can get around this issue (which is why this does not affect non-stacked/grouped bar charts), but to allow the `rRange` to provide fills I've added a guard around the fill prop like there is for stroke: `!$$props.fill && 'fill-none'`.

I've added a changeset entry for this - let me know if you need anything else or if there's any issues.