### PR TITLE
docs: Copy `Date` data as `new Date(...)` to clipboard and stringify example data to clipboard on demand

### DIFF
--- a/.changeset/cyan-hairs-march.md
+++ b/.changeset/cyan-hairs-march.md
@@ -1,0 +1,5 @@
+---
+'layerchart': patch
+---
+
+docs: Stringify example data to clipboard on demand

--- a/.changeset/loud-eagles-decide.md
+++ b/.changeset/loud-eagles-decide.md
@@ -1,0 +1,5 @@
+---
+'layerchart': patch
+---
+
+docs: Copy `Date` data as `new Date(...)` to clipboard

--- a/packages/layerchart/src/lib/docs/Preview.svelte
+++ b/packages/layerchart/src/lib/docs/Preview.svelte
@@ -22,16 +22,10 @@
   /**
    * Custom JSON replacer (to use with JSON.stringify()) to convert `Date` instances to `new Date()`
    */
-  function replacer(key: string, value: any): any {
-    // TODO: Improve handling of circular structures and other data types (Map, Set, etc)
-    if (value instanceof Date) {
-      return `new Date('${value.toISOString()}')`;
-    } else if (isLiteralObject(value)) {
-      return fromEntries(
-        entries<string, any>(value).map(([key, value]) => {
-          return [key, replacer(key, value)];
-        })
-      );
+  function replacer(this: any, key: string, value: any): any {
+    // TODO: Improve handling of circular structures and handle other data types (Map, Set, etc)
+    if (this[key] instanceof Date) {
+      return `new Date('${this[key].toISOString()}')`;
     }
 
     return value;

--- a/packages/layerchart/src/lib/docs/Preview.svelte
+++ b/packages/layerchart/src/lib/docs/Preview.svelte
@@ -7,6 +7,8 @@
 
   import { Button, CopyButton, Dialog, Toggle, Tooltip } from 'svelte-ux';
   import { cls } from '@layerstack/tailwind';
+  import { entries, fromEntries } from '@layerstack/utils';
+  import { isLiteralObject } from '@layerstack/utils/object';
 
   import Code from './Code.svelte';
   import Json from './Json.svelte';
@@ -17,12 +19,36 @@
   export let highlightedCode = code ? Prism.highlight(code, Prism.languages.svelte, language) : '';
   export let showCode = false;
 
-  let copyValue: string | null = null;
-  try {
-    // TODO: Improve handling of circular structures
-    copyValue = JSON.stringify(data, null, 2);
-  } catch (e) {
-    console.error('Error capturing value to copy', e);
+  /**
+   * Custom JSON replacer (to use with JSON.stringify()) to convert `Date` instances to `new Date()`
+   */
+  function replacer(key: string, value: any): any {
+    // TODO: Improve handling of circular structures and other data types (Map, Set, etc)
+    if (value instanceof Date) {
+      return `new Date('${value.toISOString()}')`;
+    } else if (Array.isArray(value)) {
+      return value.map((d: any) => replacer('', d));
+    } else if (isLiteralObject(value)) {
+      const foo = value;
+      return fromEntries(
+        entries<string, any>(value).map(([key, value]) => {
+          return [key, replacer(key, value)];
+        })
+      );
+    }
+
+    return value;
+  }
+
+  function getDataAsString(_data: typeof data) {
+    try {
+      // Regular expression to match quoted instantiation (ex. `"new Date(...)"`) and stripe the quotes  (`new Date(...)`)
+      const datePattern = /"(new \w+\([^)]*\))"/g;
+      return JSON.stringify(_data, replacer, 2).replace(datePattern, '$1');
+    } catch (e) {
+      console.error('Error capturing value to copy', e);
+      return '';
+    }
   }
 </script>
 
@@ -62,11 +88,9 @@
           <div class="text-lg font-semibold">Chart data</div>
         </div>
 
-        {#if copyValue}
-          <Tooltip title="Copy">
-            <CopyButton value={copyValue} variant="fill-light" color="primary" />
-          </Tooltip>
-        {/if}
+        <Tooltip title="Copy">
+          <CopyButton value={() => getDataAsString(data)} variant="fill-light" color="primary" />
+        </Tooltip>
       </div>
 
       <Json value={data} />

--- a/packages/layerchart/src/lib/docs/Preview.svelte
+++ b/packages/layerchart/src/lib/docs/Preview.svelte
@@ -26,10 +26,7 @@
     // TODO: Improve handling of circular structures and other data types (Map, Set, etc)
     if (value instanceof Date) {
       return `new Date('${value.toISOString()}')`;
-    } else if (Array.isArray(value)) {
-      return value.map((d: any) => replacer('', d));
     } else if (isLiteralObject(value)) {
-      const foo = value;
       return fromEntries(
         entries<string, any>(value).map(([key, value]) => {
           return [key, replacer(key, value)];


### PR DESCRIPTION
Closed #229

Copying to clipboard will now copy `Date` instances as `new Date('...')` instead of `'...'` to fix type issues when used with `scaleTime()`, etc (common getting started issue on Discord)

![image](https://github.com/user-attachments/assets/60a1815e-4218-4218-be5e-192b62ecc81f)

## Before
```js
[
  {
    "date": "2024-09-11T04:00:00.000Z",
    "value": 70
  },
  {
    "date": "2024-09-12T04:00:00.000Z",
    "value": 95
  },
  // ...
]
```

## After
```js
[
  {
    "date": new Date('2024-09-11T04:00:00.000Z'),
    "value": 70
  },
  {
    "date": new Date('2024-09-12T04:00:00.000Z'),
    "value": 95
  },
  // ...
]
```

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"main","parentHead":"","trunk":"main"}
```
-->
