### PR TITLE
breaking: Use camelCase (`aboveMarks`, etc) instead of kebob case (`above-marks`)` to fix Svelte 5 {#snippet} compatibility

### DIFF
--- a/.changeset/wise-taxis-greet.md
+++ b/.changeset/wise-taxis-greet.md
@@ -1,0 +1,5 @@
+---
+'layerchart': minor
+---
+
+breaking: Use camelCase (`aboveMarks`, etc) instead of kebob case (`above-marks`)` to fix Svelte 5 {#snippet} compatibility

--- a/packages/layerchart/src/lib/components/charts/AreaChart.svelte
+++ b/packages/layerchart/src/lib/components/charts/AreaChart.svelte
@@ -192,7 +192,7 @@
         {/if}
       </slot>
 
-      <slot name="below-marks" {...slotProps} />
+      <slot name="belowMarks" {...slotProps} />
 
       <slot name="marks" {...slotProps}>
         {#each series as s, i}
@@ -200,7 +200,7 @@
         {/each}
       </slot>
 
-      <slot name="above-marks" {...slotProps} />
+      <slot name="aboveMarks" {...slotProps} />
 
       <slot name="axis" {...slotProps}>
         {#if axis}

--- a/packages/layerchart/src/lib/components/charts/BarChart.svelte
+++ b/packages/layerchart/src/lib/components/charts/BarChart.svelte
@@ -245,7 +245,7 @@
         {/if}
       </slot>
 
-      <slot name="below-marks" {...slotProps} />
+      <slot name="belowMarks" {...slotProps} />
 
       <slot name="marks" {...slotProps}>
         {#each series as s, i}
@@ -253,7 +253,7 @@
         {/each}
       </slot>
 
-      <slot name="above-marks" {...slotProps} />
+      <slot name="aboveMarks" {...slotProps} />
 
       <slot name="axis" {...slotProps}>
         {#if axis}

--- a/packages/layerchart/src/lib/components/charts/LineChart.svelte
+++ b/packages/layerchart/src/lib/components/charts/LineChart.svelte
@@ -139,7 +139,7 @@
         {/if}
       </slot>
 
-      <slot name="below-marks" {...slotProps} />
+      <slot name="belowMarks" {...slotProps} />
 
       <slot name="marks" {...slotProps}>
         {#each series as s, i}
@@ -147,7 +147,7 @@
         {/each}
       </slot>
 
-      <slot name="above-marks" {...slotProps} />
+      <slot name="aboveMarks" {...slotProps} />
 
       <slot name="axis" {...slotProps}>
         {#if axis}

--- a/packages/layerchart/src/lib/components/charts/PieChart.svelte
+++ b/packages/layerchart/src/lib/components/charts/PieChart.svelte
@@ -144,7 +144,7 @@
   }}
   <slot {...slotProps}>
     <Svg center>
-      <slot name="below-marks" {...slotProps} />
+      <slot name="belowMarks" {...slotProps} />
 
       <slot name="marks" {...slotProps}>
         <Group {...props.group}>
@@ -199,7 +199,7 @@
         </Group>
       </slot>
 
-      <slot name="above-marks" {...slotProps} />
+      <slot name="aboveMarks" {...slotProps} />
     </Svg>
 
     <slot name="legend" {...slotProps}>

--- a/packages/layerchart/src/lib/components/charts/ScatterChart.svelte
+++ b/packages/layerchart/src/lib/components/charts/ScatterChart.svelte
@@ -116,7 +116,7 @@
         {/if}
       </slot>
 
-      <slot name="below-marks" {...slotProps} />
+      <slot name="belowMarks" {...slotProps} />
 
       <slot name="marks" {...slotProps}>
         {#each series as s, i}
@@ -124,7 +124,7 @@
         {/each}
       </slot>
 
-      <slot name="above-marks" {...slotProps} />
+      <slot name="aboveMarks" {...slotProps} />
 
       <slot name="axis" {...slotProps}>
         {#if axis}

--- a/packages/layerchart/src/routes/docs/components/AreaChart/+page.svelte
+++ b/packages/layerchart/src/routes/docs/components/AreaChart/+page.svelte
@@ -359,7 +359,7 @@
         },
       ]}
     >
-      <svelte:fragment slot="below-marks">
+      <svelte:fragment slot="belowMarks">
         <Spline y="avg" curve={curveCatmullRom} class="stroke-primary" />
       </svelte:fragment>
     </AreaChart>

--- a/packages/layerchart/src/routes/docs/components/BarChart/+page.svelte
+++ b/packages/layerchart/src/routes/docs/components/BarChart/+page.svelte
@@ -152,7 +152,7 @@
 <Preview data={dateSeriesData}>
   <div class="h-[300px] p-4 border rounded">
     <BarChart data={dateSeriesData} x="date" y="value" props={{ highlight: { area: false } }}>
-      <svelte:fragment slot="below-marks">
+      <svelte:fragment slot="belowMarks">
         <Highlight area={{ class: 'fill-surface-content/10' }} />
       </svelte:fragment>
     </BarChart>
@@ -755,7 +755,7 @@
 <Preview data={dateSeriesData}>
   <div class="h-[500px] p-4 border rounded">
     <BarChart data={dateSeriesData} x="value" y="date" labels orientation="horizontal" axis={false}>
-      <svelte:fragment slot="above-marks">
+      <svelte:fragment slot="aboveMarks">
         <Labels x={8} value={(d) => d.date} class="text-sm fill-surface-300 stroke-none" />
       </svelte:fragment>
     </BarChart>

--- a/packages/layerchart/src/routes/docs/components/LineChart/+page.svelte
+++ b/packages/layerchart/src/routes/docs/components/LineChart/+page.svelte
@@ -467,7 +467,7 @@
 <Preview data={dateSeriesDataWithNulls}>
   <div class="h-[300px] p-4 border rounded">
     <LineChart data={dateSeriesDataWithNulls} x="date" y="value">
-      <svelte:fragment slot="below-marks" let:series>
+      <svelte:fragment slot="belowMarks" let:series>
         {#each series as s}
           <Spline
             data={dateSeriesDataWithNulls.filter((d) => d.value !== null)}


### PR DESCRIPTION



<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"main","parentHead":"","trunk":"main"}
```
-->
