### PR TITLE
Fix passing of `strokeWidth` prop from `Bar` to `Rect`/`Spline` components

### DIFF
--- a/.changeset/big-gifts-notice.md
+++ b/.changeset/big-gifts-notice.md
@@ -1,0 +1,5 @@
+---
+'layerchart': patch
+---
+
+Fixed `strokeWidth` prop on `Bar` component.

--- a/.changeset/big-gifts-notice.md
+++ b/.changeset/big-gifts-notice.md
@@ -3,3 +3,4 @@
 ---
 
 Fixed `strokeWidth` prop on `Bar` component.
+Made `Spline` pass `{...$$restProps}` to its `<path>` element.

--- a/packages/layerchart/src/lib/components/Bar.svelte
+++ b/packages/layerchart/src/lib/components/Bar.svelte
@@ -118,7 +118,7 @@
     {spring}
     {tweened}
     {stroke}
-    stroke-width={strokeWidth}
+    {strokeWidth}
     rx={radius}
     {...dimensions}
     {...$$restProps}
@@ -135,7 +135,7 @@
     {spring}
     {tweened}
     {stroke}
-    stroke-width={strokeWidth}
+    {strokeWidth}
     {...$$restProps}
     on:click
     on:pointerenter

--- a/packages/layerchart/src/lib/components/Spline.svelte
+++ b/packages/layerchart/src/lib/components/Spline.svelte
@@ -238,6 +238,7 @@
       marker-start={markerStartId ? `url(#${markerStartId})` : undefined}
       marker-mid={markerMidId ? `url(#${markerMidId})` : undefined}
       marker-end={markerEndId ? `url(#${markerEndId})` : undefined}
+      {...$$restProps}
       in:drawTransition|global={typeof draw === 'object' ? draw : undefined}
       on:click
       on:pointerenter


### PR DESCRIPTION
Try passing a `strokeWidth` prop for a `BarChart`'s `bars` and you'll notice that nothing changes:

```svelte
<BarChart
      ...
      props={{ bars: { strokeWidth: 4 } }}
/>
```

but add `radius: 0` to the mix and suddenly things do change as expected:

```svelte
<BarChart
      ...
      props={{ bars: { radius: 0, strokeWidth: 4 } }}
/>
```

This was due to `Bar` passing its `strokeWidth` prop to `Rect`/`Spline` via `stroke-width={strokeWidth}` (instead of the provided `strokeWidth` props):

```svelte
// Bar.svelte

{#if (_rounded === 'all' || radius === 0) && renderContext === 'svg'}
  <Rect
    // ...
    stroke-width={strokeWidth} // 👈🏻 bug! this should have been just `{strokeWidth}`
    // ...
    {...$$restProps}
    // ...
  />
{:else}
  <Spline
    // ...
    stroke-width={strokeWidth} // 👈🏻 bug! this should have been just `{strokeWidth}`
    {...$$restProps}
    // ...
  />
{/if}
```

This bug was hidden for non-rounded bars (i.e. `radius = 0`) due to `Rect` passing `{...$$restProps}` to `<rect … />`, which would make the unexpected `stroke-width` prop still override the undefined `strokeWidth` prop:

```svelte
<script lang="ts">
  // ...

  export let strokeWidth: number | undefined = undefined;

  // ...
</script>

{#if renderContext === 'svg'}
  // ...
  <rect
    // ...
    stroke-width={strokeWidth}
    {...$$restProps} // 👈🏻 
    // ...
  />
{/if}
```

```svelte
// Spline.svelte
<script lang="ts">
  // ...

  export let strokeWidth: number | undefined = 4.2;

  // ...
</script>

{#if renderContext === 'svg'}
  {#key key}
    // ...
    <path
      // ...
      stroke-width={strokeWidth}
      // ... 
    />
    // ...
{/if}
```

Notice how the `Spline.svelte` component doesn't pass `{...$$restProps}` to `<path …/>`, so the `stroke-width` rest-prop passed from `Bar` never makes it to the `<path …/>` element.

---

This looks like two bugs in disguise of one to me:

1. `Bar` should forward its `strokeWidth` prop via `{strokeWidth}`, rather than `stroke-width={strokeWidth}`.
2. `Spline` should forwards its `{...$$restProps}` to its `<path>` element as that's what basically all the other basic graphic primitive components do as well.