### PR TITLE
fix: Set default series colors based on tailwind theme(). Fixes ootb support for Tailwind 4 and non-hsl based frameworks (ex. `shadcn-svelte`)

### DIFF
--- a/.changeset/silver-numbers-grow.md
+++ b/.changeset/silver-numbers-grow.md
@@ -1,0 +1,5 @@
+---
+'layerchart': patch
+---
+
+fix: Set default series colors based on tailwind theme(). Fixes ootb support for Tailwind 4 and non-hsl based frameworks (ex. `shadcn-svelte`)

--- a/packages/layerchart/src/lib/components/Chart.svelte
+++ b/packages/layerchart/src/lib/components/Chart.svelte
@@ -495,3 +495,14 @@
     {/key}
   </ChartContext>
 </LayerCake>
+
+<style>
+  :global(.layercake-container) {
+    --default-series-color-primary: theme(colors.primary);
+    --default-series-color-secondary: theme(colors.secondary);
+    --default-series-color-info: theme(colors.info);
+    --default-series-color-success: theme(colors.success);
+    --default-series-color-warning: theme(colors.warning);
+    --default-series-color-danger: theme(colors.danger);
+  }
+</style>

--- a/packages/layerchart/src/lib/components/charts/AreaChart.svelte
+++ b/packages/layerchart/src/lib/components/charts/AreaChart.svelte
@@ -68,7 +68,7 @@
     data?: TData[];
     color?: string;
     props?: Partial<ComponentProps<Area>>;
-  }[] = [{ key: 'default', value: y, color: 'hsl(var(--color-primary))' }];
+  }[] = [{ key: 'default', value: y, color: 'var(--default-series-color-primary)' }];
   $: isDefaultSeries = series.length === 1 && series[0].key === 'default';
 
   /** Determine how to layout series.  Overlap (default) or stack */

--- a/packages/layerchart/src/lib/components/charts/BarChart.svelte
+++ b/packages/layerchart/src/lib/components/charts/BarChart.svelte
@@ -312,7 +312,7 @@
   {y1Domain}
   {y1Range}
   c={isVertical ? y : x}
-  cRange={['hsl(var(--color-primary))']}
+  cRange={['var(--default-series-color-primary)']}
   padding={defaultChartPadding(axis, legend)}
   {...$$restProps}
   tooltip={$$props.tooltip === false

--- a/packages/layerchart/src/lib/components/charts/LineChart.svelte
+++ b/packages/layerchart/src/lib/components/charts/LineChart.svelte
@@ -64,7 +64,7 @@
     data?: TData[];
     color?: string;
     props?: Partial<ComponentProps<Spline>>;
-  }[] = [{ key: 'default', value: y, color: 'hsl(var(--color-primary))' }];
+  }[] = [{ key: 'default', value: y, color: 'var(--default-series-color-primary)' }];
   $: isDefaultSeries = series.length === 1 && series[0].key === 'default';
 
   export let axis: ComponentProps<Axis> | 'x' | 'y' | boolean = true;

--- a/packages/layerchart/src/lib/components/charts/PieChart.svelte
+++ b/packages/layerchart/src/lib/components/charts/PieChart.svelte
@@ -65,7 +65,7 @@
     maxValue?: number;
     color?: string;
     props?: Partial<ComponentProps<Arc>>;
-  }[] = [{ key: 'default', value: value /*, color: 'hsl(var(--color-primary))'*/ }];
+  }[] = [{ key: 'default', value: value }];
 
   export let legend: ComponentProps<Legend> | boolean = false;
 
@@ -174,12 +174,12 @@
   cRange={seriesColors.length
     ? seriesColors
     : [
-        'hsl(var(--color-primary))',
-        'hsl(var(--color-secondary))',
-        'hsl(var(--color-info))',
-        'hsl(var(--color-success))',
-        'hsl(var(--color-warning))',
-        'hsl(var(--color-danger))',
+        'var(--default-series-color-primary)',
+        'var(--default-series-color-secondary)',
+        'var(--default-series-color-info)',
+        'var(--default-series-color-success)',
+        'var(--default-series-color-warning)',
+        'var(--default-series-color-danger)',
       ]}
   padding={{ bottom: legend === true ? 32 : 0 }}
   {...$$restProps}

--- a/packages/layerchart/src/lib/components/charts/ScatterChart.svelte
+++ b/packages/layerchart/src/lib/components/charts/ScatterChart.svelte
@@ -54,7 +54,9 @@
     data: TData[];
     color?: string;
     props?: Partial<ComponentProps<Points>>;
-  }[] = [{ key: 'default', data: chartDataArray(data), color: 'hsl(var(--color-primary))' }];
+  }[] = [
+    { key: 'default', data: chartDataArray(data), color: 'var(--default-series-color-primary)' },
+  ];
   $: isDefaultSeries = series.length === 1 && series[0].key === 'default';
 
   export let axis: ComponentProps<Axis> | 'x' | 'y' | boolean = true;

--- a/packages/layerchart/src/lib/utils/canvas.ts
+++ b/packages/layerchart/src/lib/utils/canvas.ts
@@ -18,7 +18,7 @@ export type ComputedStylesOptions = {
 };
 
 /**
- * Appends or reuses `<svg>` element below `<canvas>` to resolve CSS variables and classes (ex. `stroke: hsl(var(--color-primary))` => `stroke: rgb(...)` )
+ * Appends or reuses `<svg>` element below `<canvas>` to resolve CSS variables and classes (ex. `stroke: var(--default-series-color-primary)` => `stroke: rgb(...)` )
  */
 export function getComputedStyles(
   canvas: HTMLCanvasElement,


### PR DESCRIPTION


<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"main","parentHead":"","trunk":"main"}
```
-->
