### PR TITLE
fix(Spline): Improve initial render performance when tweened disabled (default)

### DIFF
--- a/.changeset/great-lines-happen.md
+++ b/.changeset/great-lines-happen.md
@@ -1,0 +1,5 @@
+---
+'layerchart': patch
+---
+
+fix(Spline): Improve initial render performance when tweened disabled (default)

--- a/packages/layerchart/src/lib/components/Spline.svelte
+++ b/packages/layerchart/src/lib/components/Spline.svelte
@@ -124,7 +124,10 @@
 
   /** Provide initial `0` horizontal baseline and initially hide/untrack scale changes so not reactive (only set on initial mount) */
   function defaultPathData() {
-    if (pathData) {
+    if (!tweenedOptions) {
+      // If not tweened, return empty string (faster initial render)
+      return '';
+    } else if (pathData) {
       // Flatten all `y` coordinates of pre-defined `pathData`
       return flattenPathData(pathData, Math.min($yScale(0), $yRange[0]));
     } else if ($config.x) {


### PR DESCRIPTION
Toggling between "Single" and "Series" on [wide_data_processed](https://www.layerchart.com/docs/performance/wide_data_processed) perf example saw up to ~33% perf improvement on initial render (using canvas render context but similar for svg)

 
Before | After
--- | ---
![image](https://github.com/user-attachments/assets/a0ffb7cd-bacf-4ff2-88a7-fbff4729797f) | ![image](https://github.com/user-attachments/assets/c95d4942-f7f5-4a25-818b-bce5a8a911fc)

Type | Before | After | Improvement
--- | --- | --- | ---
Single | 118-136ms | 92-126ms | ~7-22%
Series | 286-297ms | 190-238ms | ~20-33%

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"main","parentHead":"","trunk":"main"}
```
-->
