### PR TITLE
Allow users to specify props for SVG and Canvas

### DIFF
--- a/.changeset/shy-peaches-talk.md
+++ b/.changeset/shy-peaches-talk.md
@@ -1,0 +1,5 @@
+---
+'layerchart': patch
+---
+
+Let users pass configurations for svg and canvas (like cursor-crosshair)

--- a/packages/layerchart/src/lib/components/charts/AreaChart.svelte
+++ b/packages/layerchart/src/lib/components/charts/AreaChart.svelte
@@ -103,6 +103,7 @@
   export let props: {
     area?: Partial<ComponentProps<Area>>;
     brush?: Partial<ComponentProps<BrushContext>>;
+    canvas?: Partial<ComponentProps<Canvas>>;
     grid?: Partial<ComponentProps<Grid>>;
     highlight?: Partial<ComponentProps<Highlight>>;
     labels?: Partial<ComponentProps<Labels>>;
@@ -110,6 +111,7 @@
     line?: Partial<ComponentProps<Line>>;
     points?: Partial<ComponentProps<Points>>;
     rule?: Partial<ComponentProps<Rule>>;
+    svg?: Partial<ComponentProps<Svg>>;
     tooltip?: {
       context?: Partial<ComponentProps<Tooltip.Context>>;
       root?: Partial<ComponentProps<Tooltip.Root>>;
@@ -350,7 +352,12 @@
   <slot {...slotProps}>
     <slot name="belowContext" {...slotProps} />
 
-    <svelte:component this={renderContext === 'canvas' ? Canvas : Svg} center={radial} {debug}>
+    <svelte:component
+      this={renderContext === 'canvas' ? Canvas : Svg}
+      {...renderContext === 'canvas' ? props.canvas : props.svg}
+      center={radial}
+      {debug}
+    >
       <slot name="grid" {...slotProps}>
         {#if grid}
           <Grid x={radial} y {...typeof grid === 'object' ? grid : null} {...props.grid} />

--- a/packages/layerchart/src/lib/components/charts/AreaChart.svelte
+++ b/packages/layerchart/src/lib/components/charts/AreaChart.svelte
@@ -354,7 +354,7 @@
 
     <svelte:component
       this={renderContext === 'canvas' ? Canvas : Svg}
-      {...renderContext === 'canvas' ? props.canvas : props.svg}
+      {(...renderContext === 'canvas' ? props.canvas : props.svg as any)}
       center={radial}
       {debug}
     >

--- a/packages/layerchart/src/lib/components/charts/AreaChart.svelte
+++ b/packages/layerchart/src/lib/components/charts/AreaChart.svelte
@@ -354,7 +354,7 @@
 
     <svelte:component
       this={renderContext === 'canvas' ? Canvas : Svg}
-      {(...renderContext === 'canvas' ? props.canvas : props.svg as any)}
+      {...(renderContext === 'canvas' ? props.canvas : props.svg) as any}
       center={radial}
       {debug}
     >

--- a/packages/layerchart/src/lib/components/charts/AreaChart.svelte
+++ b/packages/layerchart/src/lib/components/charts/AreaChart.svelte
@@ -354,7 +354,7 @@
 
     <svelte:component
       this={renderContext === 'canvas' ? Canvas : Svg}
-      {...(renderContext === 'canvas' ? props.canvas : props.svg) as any}
+      {...asAny(renderContext === 'canvas' ? props.canvas : props.svg)}
       center={radial}
       {debug}
     >

--- a/packages/layerchart/src/lib/components/charts/BarChart.svelte
+++ b/packages/layerchart/src/lib/components/charts/BarChart.svelte
@@ -360,7 +360,7 @@
 
     <svelte:component
       this={renderContext === 'canvas' ? Canvas : Svg}
-      {...(renderContext === 'canvas' ? props.canvas : props.svg) as any}
+      {...asAny(renderContext === 'canvas' ? props.canvas : props.svg)}
       {debug}
     >
       <slot name="grid" {...slotProps}>

--- a/packages/layerchart/src/lib/components/charts/BarChart.svelte
+++ b/packages/layerchart/src/lib/components/charts/BarChart.svelte
@@ -135,12 +135,14 @@
   export let props: {
     xAxis?: Partial<ComponentProps<Axis>>;
     yAxis?: Partial<ComponentProps<Axis>>;
+    canvas?: Partial<ComponentProps<Canvas>>;
     grid?: Partial<ComponentProps<Grid>>;
     rule?: Partial<ComponentProps<Rule>>;
     bars?: Partial<ComponentProps<Bars>>;
     legend?: Partial<ComponentProps<Legend>>;
     highlight?: Partial<ComponentProps<Highlight>>;
     labels?: Partial<ComponentProps<Labels>>;
+    svg?: Partial<ComponentProps<Svg>>;
     tooltip?: {
       context?: Partial<ComponentProps<Tooltip.Context>>;
       root?: Partial<ComponentProps<Tooltip.Root>>;
@@ -356,7 +358,11 @@
   <slot {...slotProps}>
     <slot name="belowContext" {...slotProps} />
 
-    <svelte:component this={renderContext === 'canvas' ? Canvas : Svg} {debug}>
+    <svelte:component
+      this={renderContext === 'canvas' ? Canvas : Svg}
+      {...(renderContext === 'canvas' ? props.canvas : props.svg) as any}
+      {debug}
+    >
       <slot name="grid" {...slotProps}>
         {#if grid}
           <Grid

--- a/packages/layerchart/src/lib/components/charts/LineChart.svelte
+++ b/packages/layerchart/src/lib/components/charts/LineChart.svelte
@@ -284,7 +284,7 @@
 
     <svelte:component
       this={renderContext === 'canvas' ? Canvas : Svg}
-      {...(renderContext === 'canvas' ? props.canvas : props.svg) as any}
+      {...asAny(renderContext === 'canvas' ? props.canvas : props.svg)}
       center={radial}
       {debug}
     >

--- a/packages/layerchart/src/lib/components/charts/LineChart.svelte
+++ b/packages/layerchart/src/lib/components/charts/LineChart.svelte
@@ -94,6 +94,7 @@
 
   export let props: {
     brush?: Partial<ComponentProps<BrushContext>>;
+    canvas?: Partial<ComponentProps<Canvas>>;
     grid?: Partial<ComponentProps<Grid>>;
     highlight?: Partial<ComponentProps<Highlight>>;
     labels?: Partial<ComponentProps<Labels>>;
@@ -101,6 +102,7 @@
     points?: Partial<ComponentProps<Points>>;
     rule?: Partial<ComponentProps<Rule>>;
     spline?: Partial<ComponentProps<Spline>>;
+    svg?: Partial<ComponentProps<Svg>>;
     tooltip?: {
       context?: Partial<ComponentProps<Tooltip.Context>>;
       root?: Partial<ComponentProps<Tooltip.Root>>;
@@ -280,7 +282,12 @@
   <slot {...slotProps}>
     <slot name="belowContext" {...slotProps} />
 
-    <svelte:component this={renderContext === 'canvas' ? Canvas : Svg} center={radial} {debug}>
+    <svelte:component
+      this={renderContext === 'canvas' ? Canvas : Svg}
+      {...(renderContext === 'canvas' ? props.canvas : props.svg) as any}
+      center={radial}
+      {debug}
+    >
       <slot name="grid" {...slotProps}>
         {#if grid}
           <Grid x={radial} y {...typeof grid === 'object' ? grid : null} {...props.grid} />

--- a/packages/layerchart/src/lib/components/charts/PieChart.svelte
+++ b/packages/layerchart/src/lib/components/charts/PieChart.svelte
@@ -115,6 +115,8 @@
     group?: Partial<ComponentProps<Group>>;
     arc?: Partial<ComponentProps<Arc>>;
     legend?: Partial<ComponentProps<Legend>>;
+    canvas?: Partial<ComponentProps<Canvas>>;
+    svg?: Partial<ComponentProps<Svg>>;
     tooltip?: {
       context?: Partial<ComponentProps<Tooltip.Context>>;
       root?: Partial<ComponentProps<Tooltip.Root>>;
@@ -217,7 +219,12 @@
   <slot {...slotProps}>
     <slot name="belowContext" {...slotProps} />
 
-    <svelte:component this={renderContext === 'canvas' ? Canvas : Svg} {center} {debug}>
+    <svelte:component
+      this={renderContext === 'canvas' ? Canvas : Svg}
+      {...(renderContext === 'canvas' ? props.canvas : props.svg) as any}
+      {center}
+      {debug}
+    >
       <slot name="belowMarks" {...slotProps} />
 
       <slot name="marks" {...slotProps}>

--- a/packages/layerchart/src/lib/components/charts/PieChart.svelte
+++ b/packages/layerchart/src/lib/components/charts/PieChart.svelte
@@ -15,6 +15,7 @@
   import * as Tooltip from '../tooltip/index.js';
 
   import { accessor, chartDataArray, type Accessor } from '../../utils/common.js';
+  import { asAny } from '../../utils/types.js';
 
   interface $$Props extends ComponentProps<Chart<TData>> {
     cornerRadius?: typeof cornerRadius;
@@ -221,7 +222,7 @@
 
     <svelte:component
       this={renderContext === 'canvas' ? Canvas : Svg}
-      {...(renderContext === 'canvas' ? props.canvas : props.svg) as any}
+      {...asAny(renderContext === 'canvas' ? props.canvas : props.svg)}
       {center}
       {debug}
     >

--- a/packages/layerchart/src/lib/components/charts/ScatterChart.svelte
+++ b/packages/layerchart/src/lib/components/charts/ScatterChart.svelte
@@ -25,6 +25,7 @@
     defaultChartPadding,
     type Accessor,
   } from '../../utils/common.js';
+  import { asAny } from '../../utils/types.js';
 
   interface $$Props extends ComponentProps<Chart<TData>> {
     axis?: typeof axis;
@@ -250,7 +251,7 @@
 
     <svelte:component
       this={renderContext === 'canvas' ? Canvas : Svg}
-      {...(renderContext === 'canvas' ? props.canvas : props.svg) as any}
+      {...asAny(renderContext === 'canvas' ? props.canvas : props.svg)}
       {debug}
     >
       <slot name="grid" {...slotProps}>

--- a/packages/layerchart/src/lib/components/charts/ScatterChart.svelte
+++ b/packages/layerchart/src/lib/components/charts/ScatterChart.svelte
@@ -72,6 +72,7 @@
 
   export let props: {
     brush?: Partial<ComponentProps<BrushContext>>;
+    canvas?: Partial<ComponentProps<Canvas>>;
     debug?: typeof debug;
     grid?: Partial<ComponentProps<Grid>>;
     highlight?: Partial<ComponentProps<Highlight>>;
@@ -80,6 +81,7 @@
     points?: Partial<ComponentProps<Points>>;
     profile?: typeof profile;
     rule?: Partial<ComponentProps<Rule>>;
+    svg?: Partial<ComponentProps<Svg>>;
     tooltip?: {
       context?: Partial<ComponentProps<Tooltip.Context>>;
       root?: Partial<ComponentProps<Tooltip.Root>>;
@@ -246,7 +248,11 @@
   <slot {...slotProps}>
     <slot name="belowContext" {...slotProps} />
 
-    <svelte:component this={renderContext === 'canvas' ? Canvas : Svg} {debug}>
+    <svelte:component
+      this={renderContext === 'canvas' ? Canvas : Svg}
+      {...(renderContext === 'canvas' ? props.canvas : props.svg) as any}
+      {debug}
+    >
       <slot name="grid" {...slotProps}>
         {#if grid}
           <Grid x y {...typeof grid === 'object' ? grid : null} {...props.grid} />

--- a/packages/layerchart/src/lib/components/layout/Canvas.svelte
+++ b/packages/layerchart/src/lib/components/layout/Canvas.svelte
@@ -112,14 +112,6 @@
   }
 
   function onPointerMove(e: PointerEvent) {
-    // const { x, y } = localPoint(e);
-
-    // if (x > 20 && y < 240) {
-    //   (e.target as Element).classList.add('cursor-crosshair');
-    // } else {
-    //   (e.target as Element).classList.remove('cursor-crosshair');
-    // }
-
     activeCanvas = true;
     const component = getPointerComponent(e);
 

--- a/packages/layerchart/src/lib/components/layout/Canvas.svelte
+++ b/packages/layerchart/src/lib/components/layout/Canvas.svelte
@@ -112,6 +112,14 @@
   }
 
   function onPointerMove(e: PointerEvent) {
+    // const { x, y } = localPoint(e);
+
+    // if (x > 20 && y < 240) {
+    //   (e.target as Element).classList.add('cursor-crosshair');
+    // } else {
+    //   (e.target as Element).classList.remove('cursor-crosshair');
+    // }
+
     activeCanvas = true;
     const component = getPointerComponent(e);
 

--- a/packages/layerchart/src/routes/docs/components/AreaChart/+page.svelte
+++ b/packages/layerchart/src/routes/docs/components/AreaChart/+page.svelte
@@ -18,7 +18,7 @@
   import { curveBasis, curveCatmullRom } from 'd3-shape';
   import { group } from 'd3-array';
   import { Button, Field, ToggleGroup, ToggleOption, Kbd, Switch } from 'svelte-ux';
-  import { format, localPoint, PeriodType } from '@layerstack/utils';
+  import { format, PeriodType } from '@layerstack/utils';
   import { addDays } from 'date-fns';
 
   import Preview from '$lib/docs/Preview.svelte';

--- a/packages/layerchart/src/routes/docs/components/AreaChart/+page.svelte
+++ b/packages/layerchart/src/routes/docs/components/AreaChart/+page.svelte
@@ -18,7 +18,7 @@
   import { curveBasis, curveCatmullRom } from 'd3-shape';
   import { group } from 'd3-array';
   import { Button, Field, ToggleGroup, ToggleOption, Kbd, Switch } from 'svelte-ux';
-  import { format, PeriodType } from '@layerstack/utils';
+  import { format, localPoint, PeriodType } from '@layerstack/utils';
   import { addDays } from 'date-fns';
 
   import Preview from '$lib/docs/Preview.svelte';
@@ -140,7 +140,28 @@
 
 <Preview data={dateSeriesData}>
   <div class="h-[300px] p-4 border rounded">
-    <AreaChart data={dateSeriesData} x="date" y="value" {renderContext} {debug} />
+    <AreaChart
+      data={dateSeriesData}
+      x="date"
+      y="value"
+      {renderContext}
+      {debug}
+      props={{
+        canvas: {
+          class: 'cursor-crosshair',
+          // onpointermove: (e) => {
+          //   console.log('onpointermove', e);
+          //   const { x, y } = localPoint(e);
+
+          //   if (x > 20 && y < 240) {
+          //     e.target.classList.add('cursor-crosshair');
+          //   } else {
+          //     e.target.classList.remove('cursor-crosshair');
+          //   }
+          // },
+        },
+      }}
+    />
   </div>
 </Preview>
 

--- a/packages/layerchart/src/routes/docs/components/AreaChart/+page.svelte
+++ b/packages/layerchart/src/routes/docs/components/AreaChart/+page.svelte
@@ -140,18 +140,7 @@
 
 <Preview data={dateSeriesData}>
   <div class="h-[300px] p-4 border rounded">
-    <AreaChart
-      data={dateSeriesData}
-      x="date"
-      y="value"
-      {renderContext}
-      {debug}
-      props={{
-        canvas: {
-          class: 'cursor-crosshair',
-        },
-      }}
-    />
+    <AreaChart data={dateSeriesData} x="date" y="value" {renderContext} {debug} />
   </div>
 </Preview>
 
@@ -1006,7 +995,6 @@
 </Preview> -->
 
 <h2>Brushing</h2>
-
 <Preview data={dateSeriesData}>
   <div class="h-[300px] p-4 border rounded">
     <AreaChart
@@ -1017,6 +1005,9 @@
       props={{
         area: { tweened: { duration: 200 } },
         xAxis: { format: undefined, tweened: { duration: 200 } },
+        canvas: {
+          class: 'cursor-crosshair',
+        },
       }}
       {renderContext}
       {debug}

--- a/packages/layerchart/src/routes/docs/components/AreaChart/+page.svelte
+++ b/packages/layerchart/src/routes/docs/components/AreaChart/+page.svelte
@@ -149,16 +149,6 @@
       props={{
         canvas: {
           class: 'cursor-crosshair',
-          // onpointermove: (e) => {
-          //   console.log('onpointermove', e);
-          //   const { x, y } = localPoint(e);
-
-          //   if (x > 20 && y < 240) {
-          //     e.target.classList.add('cursor-crosshair');
-          //   } else {
-          //     e.target.classList.remove('cursor-crosshair');
-          //   }
-          // },
         },
       }}
     />

--- a/packages/layerchart/src/routes/docs/components/AreaChart/+page.svelte
+++ b/packages/layerchart/src/routes/docs/components/AreaChart/+page.svelte
@@ -1008,6 +1008,9 @@
         canvas: {
           class: 'cursor-crosshair',
         },
+        svg: {
+          class: 'cursor-crosshair',
+        },
       }}
       {renderContext}
       {debug}


### PR DESCRIPTION
Continuing the work of letting users specify props for `svg` and `canvas`. This PR adds `canvas` and `svg` props to allow customization of rendering behavior based on the selected `renderContext`.  

Would appreciate a review to confirm that these are all the necessary places to add support for `canvas` and `svg` props!

Also, I had to cast to `any` to avoid a gnarly TypeScrip error - this may not be the best approach, so open to suggestions for a cleaner solution.  