### PR TITLE
Reactively rebuild `get_Props()` functions when `highlightSeriesKey` is updated. Fixes Svelte 3/4 reactivity issues when hovering legend, points, etc

### DIFF
--- a/.changeset/khaki-owls-argue.md
+++ b/.changeset/khaki-owls-argue.md
@@ -1,0 +1,5 @@
+---
+'layerchart': patch
+---
+
+fix: Reactively rebuild `get_Props()` functions when `highlightSeriesKey` is updated. Fixes Svelte 3/4 reactivity issues when hovering legend, points, etc

--- a/packages/layerchart/src/lib/components/charts/AreaChart.svelte
+++ b/packages/layerchart/src/lib/components/charts/AreaChart.svelte
@@ -175,7 +175,7 @@
     highlightSeriesKey = seriesKey;
   }
 
-  function getAreaProps(s: (typeof series)[number], i: number) {
+  $: getAreaProps = (s: (typeof series)[number], i: number) => {
     const lineProps = {
       ...props.line,
       ...(typeof props.area?.line === 'object' ? props.area.line : null),
@@ -219,7 +219,7 @@
     };
 
     return areaProps;
-  }
+  };
 
   function getPointsProps(s: (typeof series)[number], i: number) {
     const pointsProps: ComponentProps<Points> = {

--- a/packages/layerchart/src/lib/components/charts/BarChart.svelte
+++ b/packages/layerchart/src/lib/components/charts/BarChart.svelte
@@ -205,7 +205,7 @@
     highlightSeriesKey = seriesKey;
   }
 
-  function getBarsProps(s: (typeof series)[number], i: number) {
+  $: getBarsProps = (s: (typeof series)[number], i: number) => {
     const isFirst = i == 0;
     const isLast = i == visibleSeries.length - 1;
 
@@ -254,7 +254,7 @@
     };
 
     return barsProps;
-  }
+  };
 
   function getLabelsProps(s: (typeof series)[number], i: number) {
     const labelsProps: ComponentProps<Labels> = {

--- a/packages/layerchart/src/lib/components/charts/LineChart.svelte
+++ b/packages/layerchart/src/lib/components/charts/LineChart.svelte
@@ -141,7 +141,7 @@
     highlightSeriesKey = seriesKey;
   }
 
-  function getSplineProps(s: (typeof series)[number], i: number) {
+  $: getSplineProps = (s: (typeof series)[number], i: number) => {
     const splineProps: ComponentProps<Spline> = {
       data: s.data,
       y: s.value ?? (s.data ? undefined : s.key),
@@ -161,7 +161,7 @@
     };
 
     return splineProps;
-  }
+  };
 
   function getPointsProps(s: (typeof series)[number], i: number) {
     const pointsProps: ComponentProps<Points> = {

--- a/packages/layerchart/src/lib/components/charts/ScatterChart.svelte
+++ b/packages/layerchart/src/lib/components/charts/ScatterChart.svelte
@@ -123,7 +123,7 @@
     highlightSeriesKey = seriesKey ?? null;
   }
 
-  function getPointsProps(s: (typeof series)[number], i: number) {
+  $: getPointsProps = (s: (typeof series)[number], i: number) => {
     const pointsProps: ComponentProps<Points> = {
       data: s.data,
       stroke: s.color,
@@ -140,7 +140,7 @@
     };
 
     return pointsProps;
-  }
+  };
 
   function getLabelsProps(s: (typeof series)[number], i: number) {
     const labelsProps: ComponentProps<Labels> = {


### PR DESCRIPTION
Fixes #422

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"main","parentHead":"","trunk":"main"}
```
-->
