### PR TITLE
Fix advertant tweening due to non-granular object reactivity with tweened options

### DIFF
--- a/.changeset/flat-terms-wave.md
+++ b/.changeset/flat-terms-wave.md
@@ -1,0 +1,5 @@
+---
+'layerchart': patch
+---
+
+fix(Area|Link|Spline): Fix advertant tweening due to non-granular object reactivity with tweened options

--- a/packages/layerchart/src/lib/components/Area.svelte
+++ b/packages/layerchart/src/lib/components/Area.svelte
@@ -95,7 +95,7 @@
     return path(data ?? $contextData);
   }
 
-  $: tweenedOptions = tweened
+  const tweenedOptions = tweened
     ? { interpolate: interpolatePath, ...(typeof tweened === 'object' ? tweened : null) }
     : false;
   $: tweened_d = motionStore(defaultPathData(), { tweened: tweenedOptions });

--- a/packages/layerchart/src/lib/components/Link.svelte
+++ b/packages/layerchart/src/lib/components/Link.svelte
@@ -65,8 +65,9 @@
   $: markerEndId = markerEnd || $$slots['markerEnd'] ? uniqueId('marker-') : '';
 
   export let tweened: boolean | Parameters<typeof tweenedStore>[1] = undefined;
-  // @ts-expect-error
-  $: tweenedOptions = tweened ? { interpolate: interpolatePath, ...tweened } : false;
+  const tweenedOptions = tweened
+    ? { interpolate: interpolatePath, ...(typeof tweened === 'object' ? tweened : null) }
+    : false;
   $: tweened_d = motionStore('', { tweened: tweenedOptions });
 
   $: {

--- a/packages/layerchart/src/lib/components/Spline.svelte
+++ b/packages/layerchart/src/lib/components/Spline.svelte
@@ -149,8 +149,9 @@
   }
 
   let d: string | null = '';
-  // @ts-expect-error
-  $: tweenedOptions = tweened ? { interpolate: interpolatePath, ...tweened } : false;
+  const tweenedOptions = tweened
+    ? { interpolate: interpolatePath, ...(typeof tweened === 'object' ? tweened : null) }
+    : false;
   $: tweened_d = motionStore(defaultPathData(), { tweened: tweenedOptions });
   $: {
     const path = $radial

--- a/packages/layerchart/src/lib/utils/object.ts
+++ b/packages/layerchart/src/lib/utils/object.ts
@@ -1,0 +1,6 @@
+import { memoize } from 'lodash-es';
+
+export const memoizeObject = memoize(
+  (obj) => obj,
+  (obj) => JSON.stringify(obj)
+);

--- a/packages/layerchart/src/routes/docs/examples/Pack/+page.svelte
+++ b/packages/layerchart/src/routes/docs/examples/Pack/+page.svelte
@@ -117,7 +117,7 @@
                 stroke={hsl(nodeColor)
                   .darker(colorBy === 'children' ? 0.5 : 1)
                   .toString()}
-                stroke-width={1 / transform.scale}
+                strokeWidth={1 / transform.scale}
                 fill={nodeColor}
               />
             </Group>

--- a/packages/layerchart/src/routes/docs/examples/Sankey/+page.svelte
+++ b/packages/layerchart/src/routes/docs/examples/Sankey/+page.svelte
@@ -80,7 +80,7 @@
       <Svg>
         <Sankey nodeId={(d) => d.id} let:links let:nodes>
           {#each links as link ([link.source.id, link.target.id].join('_'))}
-            <Link sankey data={link} stroke-width={link.width} class="stroke-surface-content/10" />
+            <Link sankey data={link} strokeWidth={link.width} class="stroke-surface-content/10" />
           {/each}
           {#each nodes as node (node.id)}
             {@const nodeWidth = (node.x1 ?? 0) - (node.x0 ?? 0)}
@@ -113,7 +113,7 @@
             <Link
               sankey
               data={link}
-              stroke-width={link.width}
+              strokeWidth={link.width}
               class="stroke-surface-content/10"
               onpointermove={(e) => tooltip.show(e, { link })}
               onpointerleave={tooltip.hide}
@@ -194,7 +194,7 @@
             <Link
               sankey
               data={link}
-              stroke-width={link.width}
+              strokeWidth={link.width}
               tweened
               class="stroke-surface-content/10"
             />
@@ -267,7 +267,7 @@
               !highlightLinkIndexes.includes(link.index)
                 ? linkOpacity.inactive
                 : linkOpacity.default}
-              stroke-width={link.width}
+              strokeWidth={link.width}
               class={cls(
                 'transition[stroke-opacity] duration-300',
                 linkColorBy === 'static' && 'stroke-surface-content'
@@ -390,7 +390,7 @@
               !highlightLinkIndexes.includes(link.index)
                 ? linkOpacity.inactive
                 : linkOpacity.default}
-              stroke-width={link.width}
+              strokeWidth={link.width}
               class={cls(
                 'transition[stroke-opacity] duration-300',
                 linkColorBy === 'static' && 'stroke-surface-content'


### PR DESCRIPTION
Fixes #426 

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"main","parentHead":"","trunk":"main"}
```
-->
