### PR TITLE
fix(TransformContext): Fix `zoomTo()` regression (Pack/Zoomable map examples)

### DIFF
--- a/.changeset/some-cooks-act.md
+++ b/.changeset/some-cooks-act.md
@@ -1,0 +1,5 @@
+---
+'layerchart': patch
+---
+
+fix(TransformContext): Fix `zoomTo()` regression (Pack/Zoomable map examples)

--- a/packages/layerchart/src/lib/components/TransformContext.svelte
+++ b/packages/layerchart/src/lib/components/TransformContext.svelte
@@ -130,15 +130,15 @@
     center: { x: number; y: number },
     rect?: { width: number; height: number }
   ) {
-    // TODO: Improve with geo/projection
+    const newScale = rect ? ($width < $height ? $width / rect.width : $height / rect.height) : 1;
 
     $translate = {
-      x: $width / 2 - center.x,
-      y: $height / 2 - center.y,
+      x: $width / 2 - center.x * newScale,
+      y: $height / 2 - center.y * newScale,
     };
 
     if (rect) {
-      $scale = $width < $height ? $width / rect.width : $height / rect.height;
+      $scale = newScale;
     }
   }
 


### PR DESCRIPTION



<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"main","parentHead":"","trunk":"main"}
```
-->
