### PR TITLE
fix(TooltipContext): Properly detect non-manual modes for pointer chart bounds detection

### DIFF
--- a/.changeset/new-lights-lead.md
+++ b/.changeset/new-lights-lead.md
@@ -1,0 +1,5 @@
+---
+'layerchart': patch
+---
+
+fix(TooltipContext): Properly detect non-manual modes for pointer chart bounds detection

--- a/packages/layerchart/src/lib/components/tooltip/TooltipContext.svelte
+++ b/packages/layerchart/src/lib/components/tooltip/TooltipContext.svelte
@@ -192,7 +192,7 @@
     const point = localPoint(e, containerNode);
 
     if (
-      tooltipData === null && // mode !== 'manual' but support annotations
+      tooltipData == null && // mode !== 'manual' but support annotations
       (point.x < tooltipContextNode.offsetLeft ||
         point.x > tooltipContextNode.offsetLeft + tooltipContextNode.offsetWidth ||
         point.y < tooltipContextNode.offsetTop ||


### PR DESCRIPTION
Fixes #427

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"main","parentHead":"","trunk":"main"}
```
-->
