### PR TITLE
fix(AreaChart|LineChart): Hide highlight points when set to `false`

### DIFF
--- a/.changeset/tiny-buckets-nail.md
+++ b/.changeset/tiny-buckets-nail.md
@@ -1,0 +1,5 @@
+---
+'layerchart': patch
+---
+
+fix(AreaChart|LineChart): Hide highlight points when set to `false`

--- a/packages/layerchart/src/lib/components/charts/AreaChart.svelte
+++ b/packages/layerchart/src/lib/components/charts/AreaChart.svelte
@@ -433,15 +433,17 @@
               onpointenter={() => (highlightSeriesKey = s.key)}
               onpointleave={() => (highlightSeriesKey = null)}
               {...props.highlight}
-              points={{
-                ...highlightPointsProps,
-                fill: s.color,
-                class: cls(
-                  'transition-opacity',
-                  highlightSeriesKey && highlightSeriesKey !== s.key && 'opacity-10',
-                  highlightPointsProps?.class
-                ),
-              }}
+              points={props.highlight?.points == false
+                ? false
+                : {
+                    ...highlightPointsProps,
+                    fill: s.color,
+                    class: cls(
+                      'transition-opacity',
+                      highlightSeriesKey && highlightSeriesKey !== s.key && 'opacity-10',
+                      highlightPointsProps?.class
+                    ),
+                  }}
             />
           {/each}
         </slot>

--- a/packages/layerchart/src/lib/components/charts/LineChart.svelte
+++ b/packages/layerchart/src/lib/components/charts/LineChart.svelte
@@ -363,15 +363,17 @@
               onpointenter={() => (highlightSeriesKey = s.key)}
               onpointleave={() => (highlightSeriesKey = null)}
               {...props.highlight}
-              points={{
-                ...highlightPointsProps,
-                fill: s.color,
-                class: cls(
-                  'transition-opacity',
-                  highlightSeriesKey && highlightSeriesKey !== s.key && 'opacity-10',
-                  highlightPointsProps?.class
-                ),
-              }}
+              points={props.highlight?.points == false
+                ? false
+                : {
+                    ...highlightPointsProps,
+                    fill: s.color,
+                    class: cls(
+                      'transition-opacity',
+                      highlightSeriesKey && highlightSeriesKey !== s.key && 'opacity-10',
+                      highlightPointsProps?.class
+                    ),
+                  }}
             />
           {/each}
         </slot>


### PR DESCRIPTION



<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"main","parentHead":"","trunk":"main"}
```
-->
