### PR TITLE
fix(Canvas): Redraw if color scheme / theme changes, either via browser `prefers-color-scheme` (including emulation) or by changing `<html class="dark">` or `<html data-theme="...">`

### DIFF
--- a/.changeset/moody-donkeys-shine.md
+++ b/.changeset/moody-donkeys-shine.md
@@ -1,0 +1,5 @@
+---
+'layerchart': patch
+---
+
+fix(Canvas): Redraw if color scheme / theme changes, either via browser `prefers-color-scheme` (including emulation) or by changing `<html class="dark">` or `<html data-theme="...">`


### PR DESCRIPTION
https://github.com/user-attachments/assets/c2fc8d86-8b8a-402f-ba07-be547fe5ef7f

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"main","parentHead":"","trunk":"main"}
```
-->
