### PR TITLE
fix(TooltipContext): Ignore clicks without data (triggered from Legend clicks, for example).  Fixes #443

### DIFF
--- a/.changeset/proud-fans-rush.md
+++ b/.changeset/proud-fans-rush.md
@@ -1,0 +1,5 @@
+---
+'layerchart': patch
+---
+
+fix(TooltipContext): Ignore clicks without data (triggered from Legend clicks, for example)

--- a/packages/layerchart/src/lib/components/tooltip/TooltipContext.svelte
+++ b/packages/layerchart/src/lib/components/tooltip/TooltipContext.svelte
@@ -421,7 +421,8 @@
     hideTooltip();
   }}
   on:click={(e) => {
-    if (triggerPointerEvents) {
+    // Ignore clicks without data (triggered from Legend clicks, for example)
+    if (triggerPointerEvents && $tooltip?.data != null) {
       onclick(e, { data: $tooltip?.data });
     }
   }}


### PR DESCRIPTION



<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"main","parentHead":"","trunk":"main"}
```
-->
