### PR TITLE
(rmv) shapefile & topojson-client from deps. It's now only in devDeps

### DIFF
--- a/packages/layerchart/package.json
+++ b/packages/layerchart/package.json
@@ -106,9 +106,7 @@
     "d3-time": "^3.1.0",
     "date-fns": "^4.1.0",
     "layercake": "^8.4.2",
-    "lodash-es": "^4.17.21",
-    "shapefile": "^0.6.6",
-    "topojson-client": "^3.1.0"
+    "lodash-es": "^4.17.21"
   },
   "peerDependencies": {
     "svelte": "^3.56.0 || ^4.0.0 || ^5.0.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -104,12 +104,6 @@ importers:
       lodash-es:
         specifier: ^4.17.21
         version: 4.17.21
-      shapefile:
-        specifier: ^0.6.6
-        version: 0.6.6
-      topojson-client:
-        specifier: ^3.1.0
-        version: 3.1.0
     devDependencies:
       '@changesets/cli':
         specifier: ^2.28.1
@@ -237,6 +231,9 @@ importers:
       rehype-slug:
         specifier: ^6.0.0
         version: 6.0.0
+      shapefile:
+        specifier: ^0.6.6
+        version: 0.6.6
       solar-calculator:
         specifier: ^0.3.0
         version: 0.3.0
@@ -258,6 +255,9 @@ importers:
       tailwindcss:
         specifier: ^3.4.16
         version: 3.4.16
+      topojson-client:
+        specifier: ^3.1.0
+        version: 3.1.0
       topojson-simplify:
         specifier: ^3.0.3
         version: 3.0.3


### PR DESCRIPTION
Fix: https://github.com/techniq/layerchart/issues/452