### PR TITLE
help treeshaking imports

### DIFF
--- a/packages/layerchart/src/lib/utils/array.ts
+++ b/packages/layerchart/src/lib/utils/array.ts
@@ -1,4 +1,5 @@
-import { extent as d3extent, type Numeric } from 'd3-array';
+import type { Numeric } from 'd3-array';
+import { extent as d3extent } from 'd3-array';
 
 /**
  * Wrapper around d3-array's `extent()` but remove [undefined, undefined] return type

--- a/packages/layerchart/src/lib/utils/stack.ts
+++ b/packages/layerchart/src/lib/utils/stack.ts
@@ -1,9 +1,9 @@
 import { flatGroup, group, max, rollup, sum } from 'd3-array';
-import { stack, stackOffsetNone, stackOrderNone } from 'd3-shape';
+import { stack } from 'd3-shape';
 import { pivotWider } from './pivot.js';
 
-type OrderType = typeof stackOrderNone; // all orders share the same API
-type OffsetType = typeof stackOffsetNone; // all offsets share the same API
+type OrderType = typeof import('d3-shape').stackOrderNone; // all orders share the same API
+type OffsetType = typeof import('d3-shape').stackOffsetNone; // all offsets share the same API
 
 export function groupStackData<TData>(
   data: TData[],


### PR DESCRIPTION
Fixing this message: 

`
"stackOrderNone" is imported from external module "d3-shape" but never used in "src/routes/app/dashboard/+page.svelte", "../../node_modules/.pnpm/layerchart@1.0.7_svelte@5.23.0_ts-node@10.9.1_@types+node@22.13.1_typescript@5.8.2__typescript@5.8.2/node_modules/layerchart/dist/utils/stack.js", "../../node_modules/.pnpm/layerchart@1.0.7_svelte@5.23.0_ts-node@10.9.1_@types+node@22.13.1_typescript@5.8.2__typescript@5.8.2/node_modules/layerchart/dist/components/GeoPath.svelte", "../../node_modules/.pnpm/layerchart@1.0.7_svelte@5.23.0_ts-node@10.9.1_@types+node@22.13.1_typescript@5.8.2__typescript@5.8.2/node_modules/layerchart/dist/components/GeoSpline.svelte", "../../node_modules/.pnpm/layercake@8.4.2_svelte@5.23.0_typescript@5.8.2/node_modules/layercake/dist/lib/stack.js", "../../node_modules/.pnpm/layerchart@1.0.7_svelte@5.23.0_ts-node@10.9.1_@types+node@22.13.1_typescript@5.8.2__typescript@5.8.2/node_modules/layerchart/dist/components/Pie.svelte", "../../node_modules/.pnpm/layerchart@1.0.7_svelte@5.23.0_ts-node@10.9.1_@types+node@22.13.1_typescript@5.8.2__typescript@5.8.2/node_modules/layerchart/dist/components/Rule.svelte", "../../node_modules/.pnpm/layerchart@1.0.7_svelte@5.23.0_ts-node@10.9.1_@types+node@22.13.1_typescript@5.8.2__typescript@5.8.2/node_modules/layerchart/dist/components/Axis.svelte", "../../node_modules/.pnpm/layerchart@1.0.7_svelte@5.23.0_ts-node@10.9.1_@types+node@22.13.1_typescript@5.8.2__typescript@5.8.2/node_modules/layerchart/dist/components/Grid.svelte", "../../node_modules/.pnpm/layerchart@1.0.7_svelte@5.23.0_ts-node@10.9.1_@types+node@22.13.1_typescript@5.8.2__typescript@5.8.2/node_modules/layerchart/dist/components/Points.svelte", "../../node_modules/.pnpm/layerchart@1.0.7_svelte@5.23.0_ts-node@10.9.1_@types+node@22.13.1_typescript@5.8.2__typescript@5.8.2/node_modules/layerchart/dist/components/charts/AreaChart.svelte", "../../node_modules/.pnpm/layerchart@1.0.7_svelte@5.23.0_ts-node@10.9.1_@types+node@22.13.1_typescript@5.8.2__typescript@5.8.2/node_modules/layerchart/dist/components/charts/BarChart.svelte", "../../node_modules/.pnpm/layerchart@1.0.7_svelte@5.23.0_ts-node@10.9.1_@types+node@22.13.1_typescript@5.8.2__typescript@5.8.2/node_modules/layerchart/dist/components/Highlight.svelte", "../../node_modules/.pnpm/layerchart@1.0.7_svelte@5.23.0_ts-node@10.9.1_@types+node@22.13.1_typescript@5.8.2__typescript@5.8.2/node_modules/layerchart/dist/components/Voronoi.svelte", "../../node_modules/.pnpm/layerchart@1.0.7_svelte@5.23.0_ts-node@10.9.1_@types+node@22.13.1_typescript@5.8.2__typescript@5.8.2/node_modules/layerchart/dist/components/Link.svelte", "../../node_modules/.pnpm/layerchart@1.0.7_svelte@5.23.0_ts-node@10.9.1_@types+node@22.13.1_typescript@5.8.2__typescript@5.8.2/node_modules/layerchart/dist/components/Arc.svelte", "../../node_modules/.pnpm/layerchart@1.0.7_svelte@5.23.0_ts-node@10.9.1_@types+node@22.13.1_typescript@5.8.2__typescript@5.8.2/node_modules/layerchart/dist/components/Area.svelte", "../../node_modules/.pnpm/d3-sankey@0.12.3/node_modules/d3-sankey/src/sankeyLinkHorizontal.js", "../../node_modules/.pnpm/layerchart@1.0.7_svelte@5.23.0_ts-node@10.9.1_@types+node@22.13.1_typescript@5.8.2__typescript@5.8.2/node_modules/layerchart/dist/utils/geo.js", "../../node_modules/.pnpm/layerchart@1.0.7_svelte@5.23.0_ts-node@10.9.1_@types+node@22.13.1_typescript@5.8.2__typescript@5.8.2/node_modules/layerchart/dist/components/Spline.svelte" and "../../node_modules/.pnpm/layerchart@1.0.7_svelte@5.23.0_ts-node@10.9.1_@types+node@22.13.1_typescript@5.8.2__typescript@5.8.2/node_modules/layerchart/dist/components/Hull.svelte".
`