### PR TITLE
fix(Spline): Do not unnecessarily render mid/end markers. Fixes Firefox when used with ClipPath.

### DIFF
--- a/.changeset/kind-jokes-laugh.md
+++ b/.changeset/kind-jokes-laugh.md
@@ -1,0 +1,5 @@
+---
+'layerchart': patch
+---
+
+fix(Spline): Do not unnecessarily render mid/end markers. Fixes Firefox when used with ClipPath.

--- a/packages/layerchart/src/lib/components/Spline.svelte
+++ b/packages/layerchart/src/lib/components/Spline.svelte
@@ -303,19 +303,23 @@
     </slot>
 
     <slot name="markerMid" id={markerMidId}>
-      <Marker
-        id={markerMidId}
-        type={typeof markerMid === 'string' ? markerMid : undefined}
-        {...typeof markerMid === 'object' ? markerMid : null}
-      />
+      {#if markerMid}
+        <Marker
+          id={markerMidId}
+          type={typeof markerMid === 'string' ? markerMid : undefined}
+          {...typeof markerMid === 'object' ? markerMid : null}
+        />
+      {/if}
     </slot>
 
     <slot name="markerEnd" id={markerEndId}>
-      <Marker
-        id={markerEndId}
-        type={typeof markerEnd === 'string' ? markerEnd : undefined}
-        {...typeof markerEnd === 'object' ? markerEnd : null}
-      />
+      {#if markerEnd}
+        <Marker
+          id={markerEndId}
+          type={typeof markerEnd === 'string' ? markerEnd : undefined}
+          {...typeof markerEnd === 'object' ? markerEnd : null}
+        />
+      {/if}
     </slot>
 
     {#if $$slots.start && $startPoint}


### PR DESCRIPTION



<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"main","parentHead":"","trunk":"main"}
```
-->
