### PR TITLE
feat(BarChart): Pass derived scales (x1, y1) to slots props. Useful for custom labels with group series layout

### DIFF
--- a/.changeset/lazy-taxis-hang.md
+++ b/.changeset/lazy-taxis-hang.md
@@ -1,0 +1,5 @@
+---
+'layerchart': patch
+---
+
+feat(BarChart): Pass derived scales (x1, y1) to slots props. Useful for custom labels with group series layout

--- a/packages/layerchart/src/lib/components/charts/BarChart.svelte
+++ b/packages/layerchart/src/lib/components/charts/BarChart.svelte
@@ -329,8 +329,12 @@
   bind:tooltipContext
   let:x
   let:xScale
+  let:x1
+  let:x1Scale
+  let:y1
   let:y
   let:yScale
+  let:y1Scale
   let:c
   let:cScale
   let:width
@@ -341,8 +345,12 @@
   {@const slotProps = {
     x,
     xScale,
+    x1,
+    x1Scale,
     y,
     yScale,
+    y1,
+    y1Scale,
     c,
     cScale,
     width,


### PR DESCRIPTION



<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"main","parentHead":"","trunk":"main"}
```
-->
