### PR TITLE
fix(Axis): Fix multiline month when day tick does not align on first of month

### DIFF
--- a/.changeset/social-masks-teach.md
+++ b/.changeset/social-masks-teach.md
@@ -1,0 +1,5 @@
+---
+'layerchart': patch
+---
+
+fix(Axis): Fix multiline month when day tick does not align on first of month

--- a/packages/layerchart/src/lib/utils/ticks.ts
+++ b/packages/layerchart/src/lib/utils/ticks.ts
@@ -31,7 +31,7 @@ export function getDurationFormat(duration: Duration, multiline = false) {
       }
     } else if (+duration >= +new Duration({ duration: { days: 1 } })) {
       // Day
-      const isFirst = i === 0 || +timeMonth.floor(date) === +date;
+      const isFirst = i === 0 || date.getDate() < duration.days;
       if (multiline) {
         return (
           format(date, PeriodType.Custom, { custom: DateToken.DayOfMonth_numeric }) +


### PR DESCRIPTION
Before | After
--- | ---
![image](https://github.com/user-attachments/assets/4baa3d1f-6d73-47ca-89cd-854c87f6f0c5) | ![image](https://github.com/user-attachments/assets/fd1b7d98-c1f9-4ef7-bf3c-6d22759ff785)
