### PR TITLE
Make `ForceSimulation` generic over its nodes and links, i.e. `ForceSimulation<Node, Link>`

### DIFF
--- a/.changeset/crazy-friends-talk.md
+++ b/.changeset/crazy-friends-talk.md
@@ -1,0 +1,6 @@
+---
+'layerchart': minor
+---
+
+- Made `ForceSimulation` generic over its nodes and links, i.e. `ForceSimulation<Node, Link>.`
+- Exposed `links` via `children` snippet of `ForceSimulation`.

--- a/packages/layerchart/src/lib/components/ForceSimulation.svelte
+++ b/packages/layerchart/src/lib/components/ForceSimulation.svelte
@@ -111,6 +111,7 @@
       [
         {
           nodes: NodeDatumFor<NodeDatum>[];
+          links: LinkDatumFor<NodeDatum, LinkDatum>[];
           linkPositions: LinkPosition[];
           simulation: SimulationFor<NodeDatum, LinkDatum>;
         },
@@ -146,6 +147,9 @@
 
   let linkPositions: LinkPosition[] = $state([]);
   let simulatedNodes: NodeDatumFor<NodeDatum>[] = $state([]);
+  let simulatedLinks: LinkDatumFor<NodeDatum, LinkDatum>[] = $derived(
+    (data.links ?? []) as LinkDatumFor<NodeDatum, LinkDatum>[]
+  );
 
   // This casting is unfortunately necessary, due to unfortunate
   // overloading choices made, over at `@typed/d3-force`:
@@ -280,12 +284,10 @@
   }
 
   function updateLinkPositions() {
-    const links = data.links ?? [];
-
     // Keeping the link positions in sync with the simulation
     // so we don't need to recalculate _all_ link positions on each tick
     // which bogs down the simulation
-    linkPositions = links.map((link: any) => ({
+    linkPositions = simulatedLinks.map((link: any) => ({
       x1: link.source.x ?? 0,
       y1: link.source.y ?? 0,
       x2: link.target.x ?? 0,
@@ -420,4 +422,9 @@
   });
 </script>
 
-{@render children?.({ nodes: simulatedNodes, simulation, linkPositions })}
+{@render children?.({
+  nodes: simulatedNodes,
+  links: simulatedLinks,
+  simulation,
+  linkPositions,
+})}

--- a/packages/layerchart/src/routes/docs/examples/CollisionDetection/+page.svelte
+++ b/packages/layerchart/src/routes/docs/examples/CollisionDetection/+page.svelte
@@ -48,7 +48,12 @@
               <Group center>
                 {#each nodes as node, i}
                   {#if i > 0}
-                    <Circle cx={node.x} cy={node.y} r={node.r} fill={groupColor(node.group)} />
+                    <Circle
+                      cx={node.x}
+                      cy={node.y}
+                      r={node.r}
+                      fill={groupColor(node.group.toString())}
+                    />
                   {/if}
                 {/each}
               </Group>

--- a/packages/layerchart/src/routes/docs/examples/ForceDisjointGraph/+page.svelte
+++ b/packages/layerchart/src/routes/docs/examples/ForceDisjointGraph/+page.svelte
@@ -1,5 +1,12 @@
 <script lang="ts">
-  import { forceManyBody, forceLink, forceX, forceY } from 'd3-force';
+  import {
+    forceManyBody,
+    forceLink,
+    forceX,
+    forceY,
+    type SimulationNodeDatum,
+    type SimulationLinkDatum,
+  } from 'd3-force';
   import { curveLinear } from 'd3-shape';
   import { scaleOrdinal } from 'd3-scale';
   import { schemeCategory10 } from 'd3-scale-chromatic';
@@ -10,8 +17,19 @@
 
   let { data } = $props();
 
-  const nodes = data.miserables.nodes;
-  const links = data.miserables.links;
+  type Node = {
+    id: string;
+    group: number;
+  };
+
+  type Link = {
+    source: string;
+    target: string;
+    value: number;
+  };
+
+  const nodes: (Node & SimulationNodeDatum)[] = data.miserables.nodes;
+  const links: (Link & SimulationLinkDatum<Node & SimulationNodeDatum>)[] = data.miserables.links;
 
   const colorScale = scaleOrdinal(schemeCategory10);
 
@@ -20,6 +38,10 @@
   const chargeForce = forceManyBody().strength(-30).theta(0.9);
   const xForce = forceX();
   const yForce = forceY();
+
+  function keyForLink(link: Link & SimulationLinkDatum<Node & SimulationNodeDatum>): any {
+    return link.value + link.index!;
+  }
 </script>
 
 <h1>Examples</h1>
@@ -41,8 +63,8 @@
           }}
           data={{ nodes, links }}
         >
-          {#snippet children({ nodes, linkPositions })}
-            {#each links as link, i (link.value + link.index)}
+          {#snippet children({ nodes, links, linkPositions })}
+            {#each links as link, i (keyForLink(link))}
               <Link
                 data={link}
                 explicitCoords={linkPositions[i]}
@@ -52,7 +74,7 @@
             {/each}
 
             {#each nodes as node}
-              <Circle cx={node.x} cy={node.y} r={3} fill={colorScale(node.group)} />
+              <Circle cx={node.x} cy={node.y} r={3} fill={colorScale(node.group.toString())} />
             {/each}
           {/snippet}
         </ForceSimulation>

--- a/packages/layerchart/src/routes/docs/examples/ForceGraph/+page.svelte
+++ b/packages/layerchart/src/routes/docs/examples/ForceGraph/+page.svelte
@@ -1,5 +1,12 @@
 <script lang="ts">
-  import { forceCollide, forceManyBody, forceLink, forceCenter } from 'd3-force';
+  import {
+    forceCollide,
+    forceManyBody,
+    forceLink,
+    forceCenter,
+    type SimulationNodeDatum,
+    type SimulationLinkDatum,
+  } from 'd3-force';
   import { curveLinear } from 'd3-shape';
   import { scaleOrdinal } from 'd3-scale';
   import { schemeCategory10 } from 'd3-scale-chromatic';
@@ -11,8 +18,19 @@
 
   let { data } = $props();
 
-  const nodes = data.miserables.nodes;
-  const links = data.miserables.links;
+  type Node = {
+    id: string;
+    group: number;
+  };
+
+  type Link = {
+    source: string;
+    target: string;
+    value: number;
+  };
+
+  const nodes: (Node & SimulationNodeDatum)[] = data.miserables.nodes;
+  const links: (Link & SimulationLinkDatum<Node & SimulationNodeDatum>)[] = data.miserables.links;
 
   const colorScale = scaleOrdinal(schemeCategory10);
 
@@ -288,7 +306,7 @@
                   cx={node.x}
                   cy={node.y}
                   r={nodeRadius}
-                  fill={colorScale(node.group)}
+                  fill={colorScale(node.group.toString())}
                   stroke-width={nodeStrokeWidth}
                   class="stroke-surface-content"
                   onpointermove={(e) => context.tooltip.show(e, node)}


### PR DESCRIPTION
(This PR is stacked on top of https://github.com/techniq/layerchart/pull/526.)

I also added `links` to the arguments of `ForceSimulation`'s `children` snippet, since the user-stored `links` are merely `links: LinkDatum[]`, but the snippet-provided ones are `links: (LinkDatum & SimulationLinkDatum<LinkNode & SimulationNodeDatum>)[]`, i.e. they provide access to the simulation-specific fields.

Check out the commit _before_ the one named "Expose links via children snippet of ForceSimulation" to check out the breakage that you get without exposing `links`.

That said having `ForceSimulation` generic over `Node` and `Link` is quite nice as it means that e.g. the `simulation` passed to its `children` snippet is properly typed already.