### PR TITLE
Fix source links for `Simplified Charts` and `Tooltip` in docs; Use blob/next instead of blob/main for links.

### DIFF
--- a/packages/layerchart/src/routes/docs/+layout.svelte
+++ b/packages/layerchart/src/routes/docs/+layout.svelte
@@ -30,10 +30,16 @@
   const [type, name] = $derived(page.url.pathname.split('/').slice(2) ?? []);
   const title = $derived(page.data.meta?.title ?? name);
   const pageUrl = $derived(`src/routes/docs/${type}/${name}/+page.svelte?plain=1`);
+
+  const getComponentPath = (name: string) => {
+    if (name.endsWith('Chart') && name !== 'Chart') return `charts/${name}`;
+    if (name.startsWith('Tooltip')) return `tooltip/${name}`;
+    return name;
+  };
   const sourceUrl = $derived(
     ['components', 'utils'].includes(type)
-      ? `src/lib/${type}/${name}.${type === 'components' ? 'svelte' : 'ts'}`
-      : null
+      ? `src/lib/${type}/${getComponentPath(name)}.${type === 'components' ? 'svelte' : 'ts'}`
+      : null,
   );
   const {
     description,
@@ -121,7 +127,7 @@
         label="Source"
         {source}
         href={sourceUrl
-          ? `https://github.com/techniq/layerchart/blob/main/packages/layerchart/${sourceUrl}`
+          ? `https://github.com/techniq/layerchart/blob/next/packages/layerchart/${sourceUrl}`
           : ''}
         icon={mdiCodeTags}
       />
@@ -130,7 +136,7 @@
         label="Page source"
         source={pageSource}
         href={pageUrl
-          ? `https://github.com/techniq/layerchart/blob/main/packages/layerchart/${pageUrl}`
+          ? `https://github.com/techniq/layerchart/blob/next/packages/layerchart/${pageUrl}`
           : ''}
         icon={mdiFileDocumentEditOutline}
       />

--- a/packages/layerchart/src/routes/docs/+layout.svelte
+++ b/packages/layerchart/src/routes/docs/+layout.svelte
@@ -39,7 +39,7 @@
   const sourceUrl = $derived(
     ['components', 'utils'].includes(type)
       ? `src/lib/${type}/${getComponentPath(name)}.${type === 'components' ? 'svelte' : 'ts'}`
-      : null,
+      : null
   );
   const {
     description,


### PR DESCRIPTION
Based off issue #532.

Simplified Charts (LineChart, BarChart, ArcChart, ...) are located in `components/charts/...Chart.svelte`, but docs still reference them at `components/...Chart.svelte`. Same for Tooltip and TooltipContext (they are located at `components/tooltip/...`). 

ArcChart doesn't yet exist in `main` branch, so it's important to change blob/main links to blob/next, otherwise it will be broken, too. (as well as implementations shown on the page won't match what's at github link)

Implemented a small lookup function (`getComponentPath` at `+layout.svelte`) to correctly map component names to their nested folder paths and updated branch reference to `next` both at `Page Source` and `Source` button href's.