### PR TITLE
fix(force-simulation): Fix a bug that would sometimes keep a simulation running indefinitely

### DIFF
--- a/.changeset/khaki-pugs-hammer.md
+++ b/.changeset/khaki-pugs-hammer.md
@@ -1,0 +1,5 @@
+---
+'layerchart': patch
+---
+
+fix(force-simulation): Fixed a bug that would sometimes keep a simulation running, when its inputs change, even if `alpha < alphaMin`

--- a/packages/layerchart/src/lib/components/ForceSimulation.svelte
+++ b/packages/layerchart/src/lib/components/ForceSimulation.svelte
@@ -258,12 +258,8 @@
       // pass it to the internal d3 simulation object:
       pushAlphaToSimulation(alpha);
 
-      // Only resume the simulation as long as `alpha`
-      // is above the cut-off threshold of `alphaMin`,
-      // otherwise our simulation will never terminate:
-      if (simulation.alpha() >= simulation.alphaMin()) {
-        runOrResumeSimulation();
-      }
+      // Then we attempt to resume the simulation:
+      runOrResumeSimulation();
     }
   );
 
@@ -401,6 +397,13 @@
 
     if (staticProp) {
       // Only dynamic simulations can be resumed.
+      return;
+    }
+
+    if (simulation.alpha() < simulation.alphaMin()) {
+      // Only resume the simulation as long as `alpha`
+      // is above the cut-off threshold of `alphaMin`,
+      // otherwise our simulation will never terminate:
       return;
     }
 


### PR DESCRIPTION
I discovered the bug while experimenting with an approach of adjusting the `alphaTarget`/`alphaDecay` dynamically, based on the simulation's total kinetic energy (i.e. sum of node velocities): the simulation just kept running, despite `alpha` having dropped far, far below `0.001` already.

Any change to `alphaTarget`/`alphaDecay` caused the simulation to get restarted, even if `alpha` had already fallen below `alphaMin`.

There are a couple of places where `runOrResumeSimulation();` gets called, but currently only one of them is guarded by a `alpha >= alphaMin` check, so I move the check into `runOrResumeSimulation()` itself.

The bug is trivially reproducible by doing something like this:

```typescript
function handleTick(e: { alpha: number; alphaTarget: number }) {
    // the re-fires the simulation, but due to `alphaTarget < alphaMin` it should still terminate:
    alphaTarget = Math.random() * alphaMin;
    console.log(alpha, alphaTarget, alpha >= alphaMin);
}

<ForceSimulation {alphaTarget} onTick={handleTick} ...>...</ForceSimulation>
```