### PR TITLE
fix(Highlight): Fix display of lines for first values (`0` coord).  Fixes #568

### DIFF
--- a/.changeset/lovely-loops-ring.md
+++ b/.changeset/lovely-loops-ring.md
@@ -1,0 +1,5 @@
+---
+'layerchart': patch
+---
+
+fix(Highlight): Fix display of lines for first values (`0` coord). Fixes #568

--- a/packages/layerchart/src/lib/components/Highlight.svelte
+++ b/packages/layerchart/src/lib/components/Highlight.svelte
@@ -175,7 +175,7 @@
             y2: max(ctx.yRange) as unknown as number,
           })),
         ];
-      } else if (xCoord) {
+      } else if (xCoord != null) {
         tmpLines = [
           ...tmpLines,
           {
@@ -201,7 +201,7 @@
             y2: yItem + yOffset,
           })),
         ];
-      } else if (yCoord) {
+      } else if (yCoord != null) {
         tmpLines = [
           ...tmpLines,
           {


### PR DESCRIPTION
fix #568