### PR TITLE
fix(Axis): Fix memory leak and improve performance when tick values are `Date` instances

### DIFF
--- a/.changeset/old-lions-hide.md
+++ b/.changeset/old-lions-hide.md
@@ -1,0 +1,5 @@
+---
+'layerchart': patch
+---
+
+fix(Axis): Fix memory leak and improve performance when tick values are `Date` instances

--- a/packages/layerchart/src/lib/components/Axis.svelte
+++ b/packages/layerchart/src/lib/components/Axis.svelte
@@ -400,7 +400,7 @@
     <Text {...resolvedLabelProps} />
   {/if}
 
-  {#each tickVals as tick, index (tick)}
+  {#each tickVals as tick, index (tick.valueOf())}
     {@const tickCoords = getCoords(tick)}
     {@const [radialTickCoordsX, radialTickCoordsY] = pointRadial(tickCoords.x, tickCoords.y)}
     {@const [radialTickMarkCoordsX, radialTickMarkCoordsY] = pointRadial(


### PR DESCRIPTION
Still seeing some memory leak / DOM node increase (#585), but using `date.valueOf()` instead of `date` instances for `{#each}` keys greatly reduces the issue.  `{#each}` [docs](https://svelte.dev/docs/svelte/each#Keyed-each-blocks) state 

> The key can be any object, but strings and numbers are recommended since they allow identity to persist when the objects themselves change.

## Before

After 30s, `71,027` DOM nodes, `231MB` JS heap size

https://github.com/user-attachments/assets/fcff9088-2af0-40b2-a9a8-61d78e1ee483

## After

After 30s, `7,009` DOM nodes, `142MB` JS heap size

https://github.com/user-attachments/assets/8553e0c5-4c40-425b-a221-9cb3aa66ea9f

