### PR TITLE
fix(AnnotationPoint): Do not propagate mouse/touch move/leave events to TooltipContext after switching from pointer events. Fixes #598

### DIFF
--- a/.changeset/clean-nights-jog.md
+++ b/.changeset/clean-nights-jog.md
@@ -1,0 +1,5 @@
+---
+'layerchart': patch
+---
+
+fix(AnnotationPoint): Do not propagate mouse/touch move/leave events to TooltipContext after switching from pointer events. Fixes #598

--- a/packages/layerchart/src/lib/components/AnnotationPoint.svelte
+++ b/packages/layerchart/src/lib/components/AnnotationPoint.svelte
@@ -88,23 +88,30 @@
         ? 'start'
         : 'middle',
   });
+
+  function onPointerMove(e: PointerEvent | MouseEvent | TouchEvent) {
+    if (details) {
+      e.stopPropagation();
+      ctx.tooltip.show(e, { annotation: { label, details } });
+    }
+  }
+
+  function onPointerLeave(e: PointerEvent | MouseEvent | TouchEvent) {
+    if (details) {
+      e.stopPropagation();
+      ctx.tooltip.hide();
+    }
+  }
 </script>
 
 <Circle
   cx={point.x}
   cy={point.y}
   {r}
-  onpointermove={(e) => {
-    if (details) {
-      e.stopPropagation();
-      ctx.tooltip.show(e, { annotation: { label, details } });
-    }
-  }}
-  onpointerleave={() => {
-    if (details) {
-      ctx.tooltip.hide();
-    }
-  }}
+  onmousemove={onPointerMove}
+  ontouchmove={onPointerMove}
+  onmouseleave={onPointerLeave}
+  ontouchend={onPointerLeave}
   {...props?.circle}
   class={cls('stroke-surface-100', props?.circle?.class)}
 />

--- a/packages/layerchart/src/lib/components/tooltip/TooltipContext.svelte
+++ b/packages/layerchart/src/lib/components/tooltip/TooltipContext.svelte
@@ -22,7 +22,11 @@
     y: number;
     data: T | null;
     payload: TooltipPayload[];
-    show(e: PointerEvent, tooltipData?: any, payload?: TooltipPayload): void;
+    show(
+      e: PointerEvent | MouseEvent | TouchEvent,
+      tooltipData?: any,
+      payload?: TooltipPayload
+    ): void;
     hide(e?: PointerEvent): void;
     mode: TooltipMode;
     isHoveringTooltipArea: boolean;


### PR DESCRIPTION
fix #598