### PR TITLE
Add `onNodesChange` callback to `ForceSimulation`

### DIFF
--- a/.changeset/lemon-bats-change.md
+++ b/.changeset/lemon-bats-change.md
@@ -1,0 +1,5 @@
+---
+'layerchart': minor
+---
+
+feat(ForceSimulation): Added `onNodesChange` callback to `ForceSimulation`

--- a/packages/layerchart/src/lib/components/ForceSimulation.svelte
+++ b/packages/layerchart/src/lib/components/ForceSimulation.svelte
@@ -31,7 +31,7 @@
   > = {
     alpha: number;
     alphaTarget: number;
-    simulation: SimulationFor<NodeDatum, LinkDatum>;
+    simulation: Simulation<NodeDatum, LinkDatum>;
   };
 
   export type OnTickEvent<
@@ -40,9 +40,9 @@
   > = {
     alpha: number;
     alphaTarget: number;
-    nodes: NodeDatumFor<NodeDatum>[];
-    links: LinkDatumFor<NodeDatum, LinkDatum>[];
-    simulation: SimulationFor<NodeDatum, LinkDatum>;
+    nodes: NodeDatum[];
+    links: LinkDatum[];
+    simulation: Simulation<NodeDatum, LinkDatum>;
   };
 
   export type OnEndEvent<
@@ -51,7 +51,7 @@
   > = {
     alpha: number;
     alphaTarget: number;
-    simulation: SimulationFor<NodeDatum, LinkDatum>;
+    simulation: Simulation<NodeDatum, LinkDatum>;
   };
 
   /**
@@ -80,16 +80,6 @@
    * Default velocity decay factor applied to nodes each tick.
    */
   export const DEFAULT_VELOCITY_DECAY: number = 0.4;
-
-  type NodeDatumFor<NodeDatum> = NodeDatum & SimulationNodeDatum;
-
-  type LinkDatumFor<NodeDatum, LinkDatum> = LinkDatum &
-    SimulationLinkDatum<NodeDatumFor<NodeDatum>>;
-
-  type SimulationFor<NodeDatum, LinkDatum> = Simulation<
-    NodeDatumFor<NodeDatum>,
-    LinkDatumFor<NodeDatum, LinkDatum>
-  >;
 
   export type ForceSimulationProps<
     NodeDatum extends SimulationNodeDatum,
@@ -172,10 +162,10 @@
     children?: Snippet<
       [
         {
-          nodes: NodeDatumFor<NodeDatum>[];
-          links: LinkDatumFor<NodeDatum, LinkDatum>[];
+          nodes: NodeDatum[];
+          links: LinkDatum[];
           linkPositions: LinkPosition[];
-          simulation: SimulationFor<NodeDatum, LinkDatum>;
+          simulation: Simulation<NodeDatum, LinkDatum>;
         },
       ]
     >;
@@ -211,15 +201,13 @@
   // MARK: Private Props
 
   let linkPositions: LinkPosition[] = $state([]);
-  let simulatedNodes: NodeDatumFor<NodeDatum>[] = $state([]);
-  let simulatedLinks: LinkDatumFor<NodeDatum, LinkDatum>[] = $derived(
-    (data.links ?? []) as LinkDatumFor<NodeDatum, LinkDatum>[]
-  );
+  let simulatedNodes: NodeDatum[] = $state([]);
+  let simulatedLinks: LinkDatum[] = $derived(data.links ?? []);
 
   // This casting is unfortunately necessary, due to unfortunate
   // overloading choices made, over at `@typed/d3-force`:
-  const simulation: SimulationFor<NodeDatum, LinkDatum> = (
-    forceSimulation() as SimulationFor<NodeDatum, LinkDatum>
+  const simulation: Simulation<NodeDatum, LinkDatum> = (
+    forceSimulation<NodeDatum>() as Simulation<NodeDatum, LinkDatum>
   ).stop();
 
   // d3.Simulation does not provide a `.forces()` getter, so we need to

--- a/packages/layerchart/src/lib/components/ForceSimulation.svelte
+++ b/packages/layerchart/src/lib/components/ForceSimulation.svelte
@@ -54,6 +54,17 @@
     simulation: Simulation<NodeDatum, LinkDatum>;
   };
 
+  export type OnNodesChangeEvent<
+    NodeDatum extends SimulationNodeDatum,
+    LinkDatum extends SimulationLinkDatum<NodeDatum> | undefined,
+  > = {
+    alpha: number;
+    alphaTarget: number;
+    nodes: NodeDatum[];
+    links: LinkDatum[];
+    simulation: Simulation<NodeDatum, LinkDatum>;
+  };
+
   /**
    * Default initial alpha value of the simulation.
    */
@@ -150,6 +161,11 @@
     onStart?: (e: OnStartEvent<NodeDatum, LinkDatum | undefined>) => void;
 
     /**
+     * Callback function triggered right before nodes get passed to the simulation
+     */
+    onNodesChange?: (e: OnNodesChangeEvent<NodeDatum, LinkDatum | undefined>) => void;
+
+    /**
      * Callback function triggered on each simulation tick
      */
     onTick?: (e: OnTickEvent<NodeDatum, LinkDatum | undefined>) => void;
@@ -190,6 +206,7 @@
     stopped = false,
     static: staticProp,
     onStart: onStartProp,
+    onNodesChange: onNodesChangeProp,
     onTick: onTickProp,
     onEnd: onEndProp,
     children,
@@ -251,6 +268,7 @@
     () => {
       // Any time the `nodes` prop, or the `data` store gets changed
       // we pass them to the internal d3 simulation object:
+      onNodesChange();
       pushNodesToSimulation(data.nodes);
       runOrResumeSimulation();
     }
@@ -482,6 +500,16 @@
     onEndProp?.({
       alpha,
       alphaTarget,
+      simulation,
+    });
+  }
+
+  function onNodesChange() {
+    onNodesChangeProp?.({
+      alpha,
+      alphaTarget,
+      nodes: data.nodes,
+      links: data.links ?? [],
       simulation,
     });
   }


### PR DESCRIPTION
While working on a "newly added nodes get pre-positioned to the average position of their already-existing neighbors" feature for a graph (but the same would apply to pretty much any other imaginable pre-positioning scheme) I found that I needed a callback that would allow me to perform such pre-positioning whenever the nodes of the simulation change (that is the actual set of nodes, not merely their positions), but before the simulation has had a chance to touch the nodes (as that would result in the default behavior of positioning nodes around the origin):

```typescript
function handleNodesChange(
  event: OnNodesChangeEvent<NodeDatum, LinkDatum | undefined>
) {
  positionUninitializedNodesAtCentroidOfNeighborhood(
    event.nodes,
    event.links as LinkDatum[],
    (node) => node.id
  );
}
```

```html
<ForceSimulation
  …
  onNodesChange={handleNodesChange}
>
```