### PR TITLE
fix(Calendar): Respect `start` instead of always start of year

### DIFF
--- a/.changeset/happy-bats-eat.md
+++ b/.changeset/happy-bats-eat.md
@@ -1,0 +1,5 @@
+---
+'layerchart': patch
+---
+
+fix(Calendar): Respect `start` instead of always start of year

--- a/packages/layerchart/src/lib/components/Calendar.svelte
+++ b/packages/layerchart/src/lib/components/Calendar.svelte
@@ -107,7 +107,7 @@
     yearDays.map((date) => {
       const cellData = dataByDate.get(date) ?? { date };
       return {
-        x: timeWeek.count(timeYear(date), date) * cellSize[0],
+        x: timeWeek.count(start, date) * cellSize[0],
         y: date.getDay() * cellSize[1],
         color: ctx.config.c ? ctx.cGet(cellData) : 'transparent',
         data: cellData,
@@ -136,14 +136,19 @@
 
 {#if monthPath}
   {#each yearMonths as date}
-    <MonthPath {date} {cellSize} {...extractLayerProps(monthPath, 'lc-calendar-month-path')} />
+    <MonthPath
+      {date}
+      startOfRange={start}
+      {cellSize}
+      {...extractLayerProps(monthPath, 'lc-calendar-month-path')}
+    />
   {/each}
 {/if}
 
 {#if monthLabel}
   {#each yearMonths as date}
     <Text
-      x={timeWeek.count(timeYear.floor(date), timeWeek.ceil(date)) * cellSize[0]}
+      x={timeWeek.count(start, timeWeek.ceil(date)) * cellSize[0]}
       value={format(date, 'month', { variant: 'short' })}
       capHeight="7px"
       {...extractLayerProps(monthLabel, 'lc-calendar-month-label')}

--- a/packages/layerchart/src/lib/components/MonthPath.svelte
+++ b/packages/layerchart/src/lib/components/MonthPath.svelte
@@ -16,6 +16,11 @@
     cellSize: number | [number, number];
 
     /**
+     * The start date of the calendar (used to calculate week offsets).
+     */
+    startOfRange: Date;
+
+    /**
      * A bindable reference to the underlying `<path>` element.
      *
      * @bindable
@@ -38,6 +43,7 @@
   let {
     date,
     cellSize: cellSizeProp,
+    startOfRange,
     pathRef: pathRefProp = $bindable(),
     class: className,
     ...restProps
@@ -54,12 +60,12 @@
 
   // start of month
   const startDayOfWeek = $derived(date.getDay());
-  const startWeek = $derived(timeWeek.count(timeYear(date), date));
+  const startWeek = $derived(timeWeek.count(startOfRange, date));
 
   // end of month
   const monthEnd = $derived(endOfInterval('month', date));
   const endDayOfWeek = $derived(monthEnd.getDay());
-  const endWeek = $derived(timeWeek.count(timeYear(monthEnd), monthEnd));
+  const endWeek = $derived(timeWeek.count(startOfRange, monthEnd));
 
   const pathData = $derived(`
     M${(startWeek + 1) * cellSize[0]},${startDayOfWeek * cellSize[1]}

--- a/packages/layerchart/src/routes/docs/components/Calendar/+page.svelte
+++ b/packages/layerchart/src/routes/docs/components/Calendar/+page.svelte
@@ -8,11 +8,17 @@
   import Preview from '$lib/docs/Preview.svelte';
   import { createDateSeries } from '$lib/utils/genData.js';
   import { shared } from '../../shared.svelte.js';
-  import { endOfInterval } from '@layerstack/utils';
+  import { endOfInterval, intervalOffset, startOfInterval } from '@layerstack/utils';
 
   const now = new Date();
   const firstDayOfYear = timeYear.floor(now);
   const lastDayOfYear = endOfInterval('year', now);
+
+  const previousMonth = intervalOffset('month', now, -1);
+  const firstDayOfPreviousMonth = startOfInterval('month', previousMonth);
+  const lastDayOfPreviousMonth = endOfInterval('month', previousMonth);
+
+  const ninetyDaysAgo = intervalOffset('day', now, -90);
 
   const data = createDateSeries({ count: 365 * 4, min: 10, max: 100, value: 'integer' }).map(
     (d) => {
@@ -284,6 +290,99 @@
               {/each}
             {/snippet}
           </Calendar>
+        </Layer>
+
+        <Tooltip.Root>
+          {#snippet children({ data })}
+            <Tooltip.Header value={data.date} format="day" />
+
+            {#if data.value != null}
+              <Tooltip.List>
+                <Tooltip.Item
+                  label="value"
+                  value={data.value}
+                  format="integer"
+                  valueAlign="right"
+                />
+              </Tooltip.List>
+            {/if}
+          {/snippet}
+        </Tooltip.Root>
+      {/snippet}
+    </Chart>
+  </div>
+</Preview>
+
+<h2>Last month</h2>
+
+<Preview {data}>
+  <div class="h-[200px] p-4 border rounded-sm">
+    <Chart
+      {data}
+      x="date"
+      c="value"
+      cScale={scaleThreshold().unknown('transparent')}
+      cDomain={[25, 50, 75]}
+      cRange={[
+        'var(--color-primary-100)',
+        'var(--color-primary-300)',
+        'var(--color-primary-500)',
+        'var(--color-primary-700)',
+      ]}
+      padding={{ top: 20 }}
+    >
+      {#snippet children({ context })}
+        <Layer type={shared.renderContext}>
+          <Calendar
+            start={firstDayOfPreviousMonth}
+            end={lastDayOfPreviousMonth}
+            tooltipContext={context.tooltip}
+            monthPath
+          />
+        </Layer>
+
+        <Tooltip.Root>
+          {#snippet children({ data })}
+            <Tooltip.Header value={data.date} format="day" />
+
+            {#if data.value != null}
+              <Tooltip.List>
+                <Tooltip.Item
+                  label="value"
+                  value={data.value}
+                  format="integer"
+                  valueAlign="right"
+                />
+              </Tooltip.List>
+            {/if}
+          {/snippet}
+        </Tooltip.Root>
+      {/snippet}
+    </Chart>
+  </div>
+</Preview>
+
+<h2>90 days</h2>
+
+<Preview {data}>
+  <div class="h-[200px] p-4 border rounded-sm">
+    <Chart
+      {data}
+      x="date"
+      c="value"
+      cScale={scaleThreshold().unknown('transparent')}
+      cDomain={[25, 50, 75]}
+      cRange={[
+        'var(--color-primary-100)',
+        'var(--color-primary-300)',
+        'var(--color-primary-500)',
+        'var(--color-primary-700)',
+      ]}
+      padding={{ top: 20 }}
+    >
+      {#snippet children({ context })}
+        <Layer type={shared.renderContext}>
+          <Calendar start={ninetyDaysAgo} end={now} tooltipContext={context.tooltip} monthPath />
         </Layer>
 
         <Tooltip.Root>


### PR DESCRIPTION
<img width="1476" height="1650" alt="image" src="https://github.com/user-attachments/assets/71c605f2-91db-42f2-900b-b6bfe33dba77" />
