### PR TITLE
fix: typo ctx.config.xRange in Arc.svelte

### DIFF
--- a/packages/layerchart/src/lib/components/Arc.svelte
+++ b/packages/layerchart/src/lib/components/Arc.svelte
@@ -251,7 +251,7 @@
   const ctx = getChartContext();
 
   const endAngle = $derived(
-    endAngleProp ?? degreesToRadians(ctx.config.xRange ? max(ctx.xRange) : max(range))
+    endAngleProp ?? degreesToRadians(ctx.xRange ? max(ctx.xRange) : max(range))
   );
 
   const motionEndAngle = createMotion(initialValue, () => value, motion);


### PR DESCRIPTION
While debugging an issue I stumbled upon this line and correct me if I'm wrong, but it looks like a typo.