### PR TITLE
LineChart examples

### DIFF
--- a/docs/src/examples/LineChart/axis-labels-inside.svelte
+++ b/docs/src/examples/LineChart/axis-labels-inside.svelte
@@ -13,16 +13,14 @@
 	height={300}
 	props={{
 		yAxis: {
+			rule: true,
 			tickLabelProps: {
 				textAnchor: 'start',
-				verticalAnchor: 'end'
+				verticalAnchor: 'end',
+				x: 5
 			},
 			tickLength: 0
 		}
 	}}
-	padding={{
-		left: 0,
-		top: 10,
-		bottom: 24
-	}}
+	padding={20}
 />

--- a/docs/src/examples/LineChart/basic.svelte
+++ b/docs/src/examples/LineChart/basic.svelte
@@ -6,4 +6,4 @@
 	export { data };
 </script>
 
-<LineChart {data} x="date" y="value" height={300} />
+<LineChart {data} x="date" y="value" height={300} padding={20} />

--- a/docs/src/examples/LineChart/brush.svelte
+++ b/docs/src/examples/LineChart/brush.svelte
@@ -3,6 +3,7 @@
 	import { LineChart } from 'layerchart';
 
 	const data = await getAppleStock();
+
 	export { data };
 </script>
 
@@ -15,5 +16,6 @@
 		spline: { motion: { type: 'tween', duration: 200 } },
 		xAxis: { motion: { type: 'tween', duration: 200 }, tickMultiline: true }
 	}}
+	padding={25}
 	height={300}
 />

--- a/docs/src/examples/LineChart/curve.svelte
+++ b/docs/src/examples/LineChart/curve.svelte
@@ -4,7 +4,15 @@
 	import { createDateSeries } from '$lib/utils/data.js';
 
 	const data = createDateSeries({ count: 30, min: 50, max: 100, value: 'integer' });
+
 	export { data };
 </script>
 
-<LineChart {data} x="date" y="value" height={300} props={{ spline: { curve: curveCatmullRom } }} />
+<LineChart
+	{data}
+	x="date"
+	y="value"
+	props={{ spline: { curve: curveCatmullRom } }}
+	padding={20}
+	height={300}
+/>

--- a/docs/src/examples/LineChart/custom-tooltip.svelte
+++ b/docs/src/examples/LineChart/custom-tooltip.svelte
@@ -4,10 +4,11 @@
 	import { format } from '@layerstack/utils';
 
 	const data = createDateSeries({ count: 30, min: 50, max: 100, value: 'integer' });
+
 	export { data };
 </script>
 
-<LineChart {data} x="date" y="value" height={300}>
+<LineChart {data} x="date" y="value" padding={20} height={300}>
 	{#snippet tooltip({ context })}
 		<Tooltip.Root
 			x={context.padding.left}

--- a/docs/src/examples/LineChart/custom.svelte
+++ b/docs/src/examples/LineChart/custom.svelte
@@ -4,10 +4,11 @@
 	import { format } from '@layerstack/utils';
 
 	const data = createDateSeries({ count: 30, min: 50, max: 100, value: 'integer' });
+
 	export { data };
 </script>
 
-<LineChart {data} x="date" y="value" height={300}>
+<LineChart {data} x="date" y="value" padding={20} height={300}>
 	{#snippet children({ context })}
 		<Layer>
 			<Axis placement="left" grid rule />

--- a/docs/src/examples/LineChart/default-series-label.svelte
+++ b/docs/src/examples/LineChart/default-series-label.svelte
@@ -8,7 +8,8 @@
 			visits: d.value
 		};
 	});
+
 	export { data };
 </script>
 
-<LineChart {data} x="date" y="visits" height={300} />
+<LineChart {data} x="date" y="visits" padding={20} height={300} />

--- a/docs/src/examples/LineChart/draw.svelte
+++ b/docs/src/examples/LineChart/draw.svelte
@@ -2,20 +2,24 @@
 	import { LineChart } from 'layerchart';
 	import { createDateSeries } from '$lib/utils/data.js';
 	import { slide } from 'svelte/transition';
-	import { Field, Switch } from 'svelte-ux';
+	import ShowControl from '$lib/components/ShowControl.svelte';
 
 	const data = createDateSeries({ count: 30, min: 50, max: 100, value: 'integer' });
-	export { data };
-
 	let show = $state(true);
+
+	export { data };
 </script>
 
-<Field label="Show" labelPlacement="left" let:id class="justify-self-end mb-2">
-	<Switch {id} bind:checked={show} size="md" />
-</Field>
-
-{#if show}
-	<div transition:slide>
-		<LineChart {data} x="date" y="value" props={{ spline: { draw: true } }} height={300} />
-	</div>
-{/if}
+<ShowControl bind:show label="Show Line" />
+<div class="h-[300px]">
+	{#if show}
+		<LineChart
+			{data}
+			x="date"
+			y="value"
+			props={{ spline: { draw: true } }}
+			padding={20}
+			height={300}
+		/>
+	{/if}
+</div>

--- a/docs/src/examples/LineChart/dynamic-data.svelte
+++ b/docs/src/examples/LineChart/dynamic-data.svelte
@@ -1,8 +1,10 @@
 <script lang="ts">
 	import { LineChart } from 'layerchart';
 	import { ticks } from 'd3-array';
+	import Blockquote from '$lib/components/Blockquote.svelte';
 
 	let data = $state(ticks(-2, 2, 200).map(Math.sin));
+
 	export { data };
 </script>
 
@@ -14,6 +16,7 @@
 		data = data.slice(-200).concat(Math.atan2(x, y));
 	}}
 >
+	<Blockquote>Move your mouse over the chart to update the data</Blockquote>
 	<LineChart
 		data={data.map((d, i) => ({ x: i, y: d }))}
 		x="x"
@@ -36,6 +39,7 @@
 			//   },
 			// },
 		}}
+		padding={20}
 		height={300}
 	/>
 </div>

--- a/docs/src/examples/LineChart/gradient-encoding.svelte
+++ b/docs/src/examples/LineChart/gradient-encoding.svelte
@@ -7,14 +7,15 @@
 	import { interpolateTurbo } from 'd3-scale-chromatic';
 
 	const data = await getDailyTemperature();
-	export { data };
 
 	const temperatureColor = $derived(
 		scaleSequential(extent(data, (d) => d.value as number) as [number, number], interpolateTurbo)
 	);
+
+	export { data };
 </script>
 
-<LineChart {data} x="date" y="value" yDomain={null} height={300}>
+<LineChart {data} x="date" y="value" yDomain={null} padding={20} height={300}>
 	{#snippet marks()}
 		<LinearGradient stops={ticks(1, 0, 10).map(temperatureColor.interpolator())} vertical>
 			{#snippet children({ gradient })}

--- a/docs/src/examples/LineChart/gradient-threshold.svelte
+++ b/docs/src/examples/LineChart/gradient-threshold.svelte
@@ -4,10 +4,11 @@
 	import { format } from '@layerstack/utils';
 
 	const data = await getDailyTemperature();
+
 	export { data };
 </script>
 
-<LineChart {data} x="date" y="value" yDomain={null} height={300}>
+<LineChart {data} x="date" y="value" yDomain={null} padding={20} height={300}>
 	{#snippet marks({ context })}
 		{@const thresholdOffset =
 			context.yScale(50) / (context.height + context.padding.top + context.padding.bottom)}

--- a/docs/src/examples/LineChart/labels-with-points.svelte
+++ b/docs/src/examples/LineChart/labels-with-points.svelte
@@ -3,7 +3,8 @@
 	import { createDateSeries } from '$lib/utils/data.js';
 
 	const data = createDateSeries({ count: 30, min: 50, max: 100, value: 'integer' });
+
 	export { data };
 </script>
 
-<LineChart {data} x="date" y="value" height={300} points labels={{ offset: 10 }} />
+<LineChart {data} x="date" y="value" points labels={{ offset: 10 }} padding={20} height={300} />

--- a/docs/src/examples/LineChart/labels-within-points.svelte
+++ b/docs/src/examples/LineChart/labels-within-points.svelte
@@ -3,6 +3,7 @@
 	import { createDateSeries } from '$lib/utils/data.js';
 
 	const data = createDateSeries({ count: 30, min: 50, max: 100, value: 'integer' });
+
 	export { data };
 </script>
 
@@ -10,7 +11,6 @@
 	{data}
 	x="date"
 	y="value"
-	height={300}
 	points={{ r: 12 }}
 	labels={{ placement: 'center', class: 'text-xs fill-surface-300' }}
 	props={{
@@ -18,4 +18,6 @@
 			points: false
 		}
 	}}
+	padding={20}
+	height={300}
 />

--- a/docs/src/examples/LineChart/labels.svelte
+++ b/docs/src/examples/LineChart/labels.svelte
@@ -3,7 +3,8 @@
 	import { createDateSeries } from '$lib/utils/data.js';
 
 	const data = createDateSeries({ count: 30, min: 50, max: 100, value: 'integer' });
+
 	export { data };
 </script>
 
-<LineChart {data} x="date" y="value" height={300} labels={{ offset: 10 }} />
+<LineChart {data} x="date" y="value" labels={{ offset: 10 }} padding={20} height={300} />

--- a/docs/src/examples/LineChart/large-radial-series.svelte
+++ b/docs/src/examples/LineChart/large-radial-series.svelte
@@ -4,6 +4,7 @@
 	import { getDailyTemperatures } from '$lib/data.remote';
 
 	const data = await getDailyTemperatures();
+
 	export { data };
 </script>
 
@@ -35,5 +36,6 @@
 			props: { opacity: year === 2024 ? 1 : year === 2023 ? 0.5 : 0.1 }
 		};
 	})}
+	padding={20}
 	height={500}
 />

--- a/docs/src/examples/LineChart/large-series.svelte
+++ b/docs/src/examples/LineChart/large-series.svelte
@@ -4,6 +4,7 @@
 	import { getDailyTemperatures } from '$lib/data.remote';
 
 	const data = await getDailyTemperatures();
+
 	export { data };
 </script>
 
@@ -30,5 +31,6 @@
 			props: { opacity: year === 2024 ? 1 : year === 2023 ? 0.5 : 0.1 }
 		};
 	})}
+	padding={{ left: 40, top: 20, right: 20, bottom: 20 }}
 	height={500}
 />

--- a/docs/src/examples/LineChart/legend.svelte
+++ b/docs/src/examples/LineChart/legend.svelte
@@ -9,6 +9,7 @@
 		value: 'integer',
 		keys: ['apples', 'bananas', 'oranges']
 	});
+
 	export { data };
 </script>
 
@@ -26,6 +27,7 @@
 			color: 'var(--color-warning)'
 		}
 	]}
+	padding={{ left: 20, top: 20, right: 20, bottom: 50 }}
 	height={300}
 	legend
 />

--- a/docs/src/examples/LineChart/line-annotation.svelte
+++ b/docs/src/examples/LineChart/line-annotation.svelte
@@ -3,6 +3,7 @@
 	import { getAppleStock } from '$lib/data.remote';
 
 	const data = await getAppleStock();
+
 	export { data };
 </script>
 
@@ -10,7 +11,6 @@
 	{data}
 	x="date"
 	y="value"
-	height={300}
 	annotations={[
 		{
 			type: 'line',
@@ -24,4 +24,6 @@
 			}
 		}
 	]}
+	padding={20}
+	height={300}
 />

--- a/docs/src/examples/LineChart/null-dashed-gaps.svelte
+++ b/docs/src/examples/LineChart/null-dashed-gaps.svelte
@@ -8,10 +8,11 @@
 			value: Math.random() < 0.2 ? null : d.value
 		};
 	});
+
 	export { data };
 </script>
 
-<LineChart {data} x="date" y="value" height={300}>
+<LineChart {data} x="date" y="value" padding={20} height={300}>
 	{#snippet belowMarks({ series })}
 		{#each series as s}
 			<Spline

--- a/docs/src/examples/LineChart/null-gaps.svelte
+++ b/docs/src/examples/LineChart/null-gaps.svelte
@@ -8,7 +8,8 @@
 			value: Math.random() < 0.2 ? null : d.value
 		};
 	});
+
 	export { data };
 </script>
 
-<LineChart {data} x="date" y="value" points height={300} />
+<LineChart {data} x="date" y="value" points padding={20} height={300} />

--- a/docs/src/examples/LineChart/oscilloscope-time.svelte
+++ b/docs/src/examples/LineChart/oscilloscope-time.svelte
@@ -1,11 +1,19 @@
 <script lang="ts">
-	import { LineChart } from 'layerchart';
+	import { LineChart, LinearGradient, Spline } from 'layerchart';
 	import { Button } from 'svelte-ux';
+	import { scaleSequential } from 'd3-scale';
+	import { interpolateViridis } from 'd3-scale-chromatic';
+	import { ticks } from 'd3-array';
 
 	import LucideCirclePlay from '~icons/lucide/circle-play';
 	import LucideCircleStop from '~icons/lucide/circle-stop';
 
 	const FFT_SIZE = 1024;
+
+	// Color scale based on y-value range
+	const yMin = -256;
+	const yMax = 512;
+	const heightColor = $derived(scaleSequential([yMin, yMax], interpolateViridis));
 
 	// Generate mock time domain data for demonstration
 	const mockData = Array.from({ length: 512 }, (_, i) => ({
@@ -123,10 +131,18 @@
 	{data}
 	x="key"
 	y="value"
-	yDomain={[-256, 512]}
+	yDomain={[yMin, yMax]}
 	axis={false}
 	grid={false}
-	props={{ spline: { class: 'stroke-surface-content' } }}
 	tooltip={{ mode: 'manual' }}
+	padding={20}
 	height={200}
-/>
+>
+	{#snippet marks()}
+		<LinearGradient stops={ticks(1, 0, 10).map(heightColor.interpolator())} vertical>
+			{#snippet children({ gradient })}
+				<Spline stroke={gradient} class="stroke-2" />
+			{/snippet}
+		</LinearGradient>
+	{/snippet}
+</LineChart>

--- a/docs/src/examples/LineChart/override-color.svelte
+++ b/docs/src/examples/LineChart/override-color.svelte
@@ -8,6 +8,7 @@
 			visits: d.value
 		};
 	});
+
 	export { data };
 </script>
 
@@ -15,5 +16,6 @@
 	{data}
 	x="date"
 	series={[{ key: 'value', color: 'var(--color-secondary)' }]}
+	padding={20}
 	height={300}
 />

--- a/docs/src/examples/LineChart/point-annotations.svelte
+++ b/docs/src/examples/LineChart/point-annotations.svelte
@@ -4,6 +4,7 @@
 	import { getAppleStock } from '$lib/data.remote';
 
 	const data = await getAppleStock();
+
 	export { data };
 
 	// Get a few random points to use for annotations
@@ -38,6 +39,7 @@
 		};
 	})}
 	height={300}
+	padding={20}
 >
 	{#snippet tooltip({ context })}
 		<Tooltip.Root>

--- a/docs/src/examples/LineChart/points.svelte
+++ b/docs/src/examples/LineChart/points.svelte
@@ -3,7 +3,8 @@
 	import { createDateSeries } from '$lib/utils/data.js';
 
 	const data = createDateSeries({ count: 30, min: 50, max: 100, value: 'integer' });
+
 	export { data };
 </script>
 
-<LineChart {data} x="date" y="value" height={300} points />
+<LineChart {data} x="date" y="value" points padding={20} height={300} />

--- a/docs/src/examples/LineChart/radar-rounded.svelte
+++ b/docs/src/examples/LineChart/radar-rounded.svelte
@@ -9,6 +9,7 @@
 		{ name: 'cutter', value: 8 },
 		{ name: 'curve', value: 5 }
 	];
+
 	export { data };
 </script>
 
@@ -16,7 +17,6 @@
 	{data}
 	x="name"
 	y="value"
-	padding={{ top: 8 }}
 	radial
 	points
 	props={{
@@ -43,5 +43,6 @@
 			}
 		}
 	}}
+	padding={20}
 	height={300}
 />

--- a/docs/src/examples/LineChart/radar-series.svelte
+++ b/docs/src/examples/LineChart/radar-series.svelte
@@ -34,6 +34,7 @@
 			actual: 21000
 		}
 	];
+
 	export { data };
 </script>
 
@@ -77,5 +78,6 @@
 			}
 		}
 	}}
+	padding={20}
 	height={300}
 />

--- a/docs/src/examples/LineChart/radar.svelte
+++ b/docs/src/examples/LineChart/radar.svelte
@@ -9,6 +9,7 @@
 		{ name: 'cutter', value: 8 },
 		{ name: 'curve', value: 5 }
 	];
+
 	export { data };
 </script>
 
@@ -17,7 +18,6 @@
 	x="name"
 	y="value"
 	yPadding={[0, 8]}
-	padding={{ top: 8 }}
 	radial
 	points
 	props={{
@@ -45,5 +45,6 @@
 			}
 		}
 	}}
+	padding={20}
 	height={300}
 />

--- a/docs/src/examples/LineChart/range-annotation.svelte
+++ b/docs/src/examples/LineChart/range-annotation.svelte
@@ -3,6 +3,7 @@
 	import { getAppleStock } from '$lib/data.remote';
 
 	const data = await getAppleStock();
+
 	export { data };
 </script>
 
@@ -10,7 +11,6 @@
 	{data}
 	x="date"
 	y="value"
-	height={300}
 	annotations={[
 		{
 			type: 'range',
@@ -27,4 +27,6 @@
 			}
 		}
 	]}
+	padding={20}
+	height={300}
 />

--- a/docs/src/examples/LineChart/series-brush.svelte
+++ b/docs/src/examples/LineChart/series-brush.svelte
@@ -9,6 +9,7 @@
 		value: 'integer',
 		keys: ['apples', 'bananas', 'oranges']
 	});
+
 	export { data };
 </script>
 
@@ -31,5 +32,6 @@
 		alert(JSON.stringify(detail));
 	}}
 	brush
+	padding={20}
 	height={300}
 />

--- a/docs/src/examples/LineChart/series-custom-highlight-point.svelte
+++ b/docs/src/examples/LineChart/series-custom-highlight-point.svelte
@@ -9,6 +9,7 @@
 		value: 'integer',
 		keys: ['apples', 'bananas', 'oranges']
 	});
+
 	export { data };
 </script>
 
@@ -27,5 +28,6 @@
 		}
 	]}
 	props={{ highlight: { points: { r: 8, strokeWidth: 4 } } }}
+	padding={20}
 	height={300}
 />

--- a/docs/src/examples/LineChart/series-individual-tooltip.svelte
+++ b/docs/src/examples/LineChart/series-individual-tooltip.svelte
@@ -16,6 +16,7 @@
 
 	const flatData = pivotLonger(data, keys, 'fruit', 'value');
 	const dataByFruit = group(flatData, (d) => d.fruit);
+
 	export { dataByFruit as data };
 </script>
 
@@ -31,6 +32,7 @@
 	props={{ tooltip: { context: { mode: 'quadtree' } } }}
 	brush
 	legend
+	padding={{ left: 20, top: 20, right: 20, bottom: 50 }}
 	height={300}
 >
 	{#snippet marks({ context, visibleSeries, highlightKey })}

--- a/docs/src/examples/LineChart/series-labels-hover.svelte
+++ b/docs/src/examples/LineChart/series-labels-hover.svelte
@@ -9,6 +9,7 @@
 		value: 'integer',
 		keys: ['apples', 'bananas', 'oranges']
 	});
+
 	export { data };
 </script>
 

--- a/docs/src/examples/LineChart/series-point-annotations.svelte
+++ b/docs/src/examples/LineChart/series-point-annotations.svelte
@@ -14,7 +14,6 @@
 
 	const flatData = pivotLonger(data, keys, 'fruit', 'value');
 	const dataByFruit = group(flatData, (d) => d.fruit);
-	export { dataByFruit as data };
 
 	const series = $derived([
 		{
@@ -33,6 +32,8 @@
 			color: 'var(--color-warning)'
 		}
 	]);
+
+	export { dataByFruit as data };
 </script>
 
 <LineChart

--- a/docs/src/examples/LineChart/series-point-click.svelte
+++ b/docs/src/examples/LineChart/series-point-click.svelte
@@ -9,6 +9,7 @@
 		value: 'integer',
 		keys: ['apples', 'bananas', 'oranges']
 	});
+
 	export { data };
 </script>
 
@@ -30,5 +31,6 @@
 		console.log(e, detail);
 		alert(JSON.stringify(detail));
 	}}
+	padding={20}
 	height={300}
 />

--- a/docs/src/examples/LineChart/series-separate-data-diff-length.svelte
+++ b/docs/src/examples/LineChart/series-separate-data-diff-length.svelte
@@ -14,6 +14,7 @@
 
 	const flatData = pivotLonger(data, keys, 'fruit', 'value');
 	const dataByFruit = group(flatData, (d) => d.fruit);
+
 	export { dataByFruit as data };
 </script>
 
@@ -37,5 +38,6 @@
 			color: 'var(--color-warning)'
 		}
 	]}
+	padding={20}
 	height={300}
 />

--- a/docs/src/examples/LineChart/series-separate-data.svelte
+++ b/docs/src/examples/LineChart/series-separate-data.svelte
@@ -14,6 +14,7 @@
 
 	const flatData = pivotLonger(data, keys, 'fruit', 'value');
 	const dataByFruit = group(flatData, (d) => d.fruit);
+
 	export { dataByFruit as data };
 </script>
 
@@ -37,5 +38,6 @@
 			color: 'var(--color-warning)'
 		}
 	]}
+	padding={20}
 	height={300}
 />

--- a/docs/src/examples/LineChart/series-vertical.svelte
+++ b/docs/src/examples/LineChart/series-vertical.svelte
@@ -12,21 +12,24 @@
 	export { data };
 </script>
 
-<LineChart
-	{data}
-	y="date"
-	series={[
-		{ key: 'apples', color: 'var(--color-danger)' },
-		{
-			key: 'bananas',
-			color: 'var(--color-success)'
-		},
-		{
-			key: 'oranges',
-			color: 'var(--color-warning)'
-		}
-	]}
-	orientation="vertical"
-	height={600}
-	width={400}
-/>
+<div class="flex justify-center">
+	<LineChart
+		{data}
+		y="date"
+		series={[
+			{ key: 'apples', color: 'var(--color-danger)' },
+			{
+				key: 'bananas',
+				color: 'var(--color-success)'
+			},
+			{
+				key: 'oranges',
+				color: 'var(--color-warning)'
+			}
+		]}
+		orientation="vertical"
+		padding={20}
+		height={600}
+		width={400}
+	/>
+</div>

--- a/docs/src/examples/LineChart/series-with-nulls.svelte
+++ b/docs/src/examples/LineChart/series-with-nulls.svelte
@@ -18,6 +18,7 @@
 		});
 		return newItem;
 	});
+
 	export { data };
 </script>
 
@@ -29,6 +30,7 @@
 		{ key: 'bananas', color: 'var(--color-success)' },
 		{ key: 'oranges', color: 'var(--color-warning)' }
 	]}
+	padding={20}
 	height={300}
 >
 	{#snippet belowMarks({ visibleSeries, highlightKey })}

--- a/docs/src/examples/LineChart/series.svelte
+++ b/docs/src/examples/LineChart/series.svelte
@@ -9,6 +9,7 @@
 		value: 'integer',
 		keys: ['apples', 'bananas', 'oranges']
 	});
+
 	export { data };
 </script>
 
@@ -26,5 +27,6 @@
 			color: 'var(--color-warning)'
 		}
 	]}
+	padding={20}
 	height={300}
 />

--- a/docs/src/examples/LineChart/single-axis-x.svelte
+++ b/docs/src/examples/LineChart/single-axis-x.svelte
@@ -3,7 +3,8 @@
 	import { createDateSeries } from '$lib/utils/data.js';
 
 	const data = createDateSeries({ count: 30, min: 50, max: 100, value: 'integer' });
+
 	export { data };
 </script>
 
-<LineChart {data} x="date" y="value" axis="x" height={300} />
+<LineChart {data} x="date" y="value" axis="x" padding={20} height={300} />

--- a/docs/src/examples/LineChart/single-axis-y.svelte
+++ b/docs/src/examples/LineChart/single-axis-y.svelte
@@ -3,7 +3,8 @@
 	import { createDateSeries } from '$lib/utils/data.js';
 
 	const data = createDateSeries({ count: 30, min: 50, max: 100, value: 'integer' });
+
 	export { data };
 </script>
 
-<LineChart {data} x="date" y="value" axis="y" height={300} />
+<LineChart {data} x="date" y="value" axis="y" padding={20} height={300} />

--- a/docs/src/examples/LineChart/sparkline-fixed-position-tooltip.svelte
+++ b/docs/src/examples/LineChart/sparkline-fixed-position-tooltip.svelte
@@ -17,6 +17,7 @@
 	props={{
 		highlight: { points: { r: 3, class: 'stroke-2 stroke-surface-100' } }
 	}}
+	padding={{ left: 20 }}
 	width={124}
 	height={24}
 >
@@ -26,7 +27,7 @@
 			class="text-xs"
 			contained={false}
 			y={-3}
-			x={context.width + 8}
+			x={context.width + 35}
 			variant="none"
 		>
 			{#snippet children({ data })}
@@ -34,7 +35,7 @@
 					{format(data.date, 'day')}
 				</div>
 				<div class="font-semibold">
-					{data.value}
+					{format(data.value, 'decimal', { minimumFractionDigits: 1, maximumFractionDigits: 1 })}
 				</div>
 			{/snippet}
 		</Tooltip.Root>

--- a/docs/src/examples/LineChart/sparkline-within-a-paragraph-with-tooltip-and-highlight.svelte
+++ b/docs/src/examples/LineChart/sparkline-within-a-paragraph-with-tooltip-and-highlight.svelte
@@ -8,7 +8,7 @@
 	export { data };
 </script>
 
-<p>
+<p class="px-4 py-2">
 	Lorem ipsum dolor sit amet, consectetur adipiscing elit. Etiam pretium, ligula ac sollicitudin
 	ullamcorper, leo justo pretium tellus, at gravida ex quam et orci.
 	<LineChart
@@ -21,6 +21,7 @@
 		props={{
 			highlight: { points: { r: 3, class: 'stroke-2 stroke-surface-100' } }
 		}}
+		padding={5}
 		height={18}
 		width={124}
 		class="inline-block"
@@ -32,7 +33,7 @@
 						{format(data.date, 'day')}
 					</div>
 					<div class="font-semibold">
-						{data.value}
+						{format(data.value, 'decimal', { minimumFractionDigits: 1, maximumFractionDigits: 1 })}
 					</div>
 				{/snippet}
 			</Tooltip.Root>

--- a/docs/src/examples/LineChart/sparkline-within-a-paragraph.svelte
+++ b/docs/src/examples/LineChart/sparkline-within-a-paragraph.svelte
@@ -6,7 +6,7 @@
 	export { data };
 </script>
 
-<p>
+<p class="px-4 py-2">
 	Lorem ipsum dolor sit amet, consectetur adipiscing elit. Etiam pretium, ligula ac sollicitudin
 	ullamcorper, leo justo pretium tellus, at gravida ex quam et orci.
 	<LineChart
@@ -19,6 +19,7 @@
 		props={{
 			highlight: { points: { r: 3, class: 'stroke-2 stroke-surface-100' } }
 		}}
+		padding={5}
 		height={18}
 		width={124}
 		class="inline-block"

--- a/docs/src/examples/LineChart/sparkline-zero-axis.svelte
+++ b/docs/src/examples/LineChart/sparkline-zero-axis.svelte
@@ -3,6 +3,7 @@
 	import { createDateSeries } from '$lib/utils/data.js';
 
 	const data = createDateSeries({ count: 50, min: 50, max: 100 });
+
 	export { data };
 </script>
 
@@ -15,6 +16,7 @@
 	props={{
 		highlight: { points: { r: 3, class: 'stroke-2 stroke-surface-100' } }
 	}}
+	padding={{ left: 20 }}
 	width={124}
 	height={20}
 />

--- a/docs/src/examples/LineChart/sparkline.svelte
+++ b/docs/src/examples/LineChart/sparkline.svelte
@@ -3,6 +3,7 @@
 	import { createDateSeries } from '$lib/utils/data.js';
 
 	const data = createDateSeries({ count: 50, min: 50, max: 100 });
+
 	export { data };
 </script>
 
@@ -16,6 +17,7 @@
 	props={{
 		highlight: { points: { r: 3, class: 'stroke-2 stroke-surface-100' } }
 	}}
+	padding={{ left: 20 }}
 	width={124}
 	height={18}
 />

--- a/docs/src/examples/LineChart/tooltip-click.svelte
+++ b/docs/src/examples/LineChart/tooltip-click.svelte
@@ -3,6 +3,7 @@
 	import { createDateSeries } from '$lib/utils/data.js';
 
 	const data = createDateSeries({ count: 30, min: 50, max: 100, value: 'integer' });
+
 	export { data };
 </script>
 
@@ -10,9 +11,10 @@
 	{data}
 	x="date"
 	y="value"
-	height={300}
 	onTooltipClick={(e, detail) => {
 		console.log(e, detail);
 		alert(JSON.stringify(detail));
 	}}
+	padding={20}
+	height={300}
 />

--- a/docs/src/examples/LineChart/vertical.svelte
+++ b/docs/src/examples/LineChart/vertical.svelte
@@ -3,7 +3,18 @@
 	import { createDateSeries } from '$lib/utils/data.js';
 
 	const data = createDateSeries({ count: 30, min: 50, max: 100, value: 'integer' });
+
 	export { data };
 </script>
 
-<LineChart {data} x="value" y="date" orientation="vertical" width={400} height={600} />
+<div class="flex justify-center">
+	<LineChart
+		{data}
+		x="value"
+		y="date"
+		orientation="vertical"
+		padding={20}
+		width={400}
+		height={600}
+	/>
+</div>


### PR DESCRIPTION
- padding changes to canvas does not cut off labels.
- "draw"
  - split out controls
  - reinstated wrapping div to keep from collapsing w/show/hide
- "axis-label-inside" added y-rule to better demonstrate
- "series-vertical" and "vertical" centered with  wrapping div
- "dynamic-data" added blockquote for ">Move your mouse over the chart to update the data" 
-"oscilloscope-time" added gradient color encoding of amplitude.