### PR TITLE
Chart examples

### DIFF
--- a/docs/src/examples/Chart/compound-common-scale-with-extra-marks.svelte
+++ b/docs/src/examples/Chart/compound-common-scale-with-extra-marks.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import { Area, BarChart, Tooltip } from 'layerchart';
 	import { createDateSeries } from '$lib/utils/data.js';
+	import { timeDay } from 'd3-time';
 
 	const data = createDateSeries({
 		count: 30,
@@ -9,6 +10,7 @@
 		value: 'integer',
 		keys: ['value', 'baseline']
 	});
+
 	export { data };
 </script>
 
@@ -16,9 +18,11 @@
 	{data}
 	x="date"
 	y={['baseline', 'value']}
+	xInterval={timeDay}
 	props={{
 		bars: { y: 'baseline' }
 	}}
+	padding={20}
 	height={300}
 >
 	{#snippet aboveMarks()}

--- a/docs/src/examples/Chart/compound-dual-axis-with-single-chart-using-remapped-scale.svelte
+++ b/docs/src/examples/Chart/compound-dual-axis-with-single-chart-using-remapped-scale.svelte
@@ -4,6 +4,7 @@
 	import { getNewPassengerCars } from '$lib/data.remote.js';
 
 	const data = await getNewPassengerCars();
+
 	export { data };
 </script>
 
@@ -16,8 +17,8 @@
 	yNice
 	y1="efficiency"
 	y1Range={({ yScale }) => yScale.domain()}
-	padding={{ top: 24, bottom: 24, left: 24, right: 24 }}
 	tooltip={{ mode: 'quadtree-x' }}
+	padding={30}
 	height={300}
 >
 	{#snippet children({ context })}

--- a/docs/src/examples/Chart/compound-dual-axis-with-stacked-charts.svelte
+++ b/docs/src/examples/Chart/compound-dual-axis-with-stacked-charts.svelte
@@ -3,20 +3,13 @@
 	import { getNewPassengerCars } from '$lib/data.remote.js';
 
 	const data = await getNewPassengerCars();
+
 	export { data };
 </script>
 
-<div class="grid grid-stack p-4 border rounded-sm">
+<div class="grid grid-stack p-6">
 	<!-- Sales chart-->
-	<Chart
-		{data}
-		x="year"
-		y="sales"
-		yDomain={[0, null]}
-		yNice
-		padding={{ top: 24, bottom: 24, left: 24, right: 24 }}
-		height={300}
-	>
+	<Chart {data} x="year" y="sales" yDomain={[0, null]} yNice height={300}>
 		<Layer>
 			<Axis
 				placement="left"
@@ -33,13 +26,7 @@
 	</Chart>
 
 	<!-- Efficiency chart, provides tooltip for both values  -->
-	<Chart
-		{data}
-		x="year"
-		y="efficiency"
-		padding={{ top: 24, bottom: 24, left: 24, right: 24 }}
-		tooltip={{ mode: 'quadtree-x' }}
-	>
+	<Chart {data} x="year" y="efficiency" tooltip={{ mode: 'quadtree-x' }}>
 		<Layer>
 			<Axis
 				placement="right"

--- a/docs/src/examples/Chart/compound-separate-scales-with-stacked-charts-and-overridden-marks.svelte
+++ b/docs/src/examples/Chart/compound-separate-scales-with-stacked-charts-and-overridden-marks.svelte
@@ -3,10 +3,11 @@
 	import { getAppleTicker } from '$lib/data.remote.js';
 
 	const data = await getAppleTicker();
+
 	export { data };
 </script>
 
-<div class="grid grid-stack p-4 border rounded-sm">
+<div class="grid grid-stack p-4">
 	<!-- First chart (bar), with different domain scale for volume -->
 	<BarChart
 		{data}

--- a/docs/src/examples/Chart/compound-separate-scales-with-stacked-charts-with-inverted-range-top-down.svelte
+++ b/docs/src/examples/Chart/compound-separate-scales-with-stacked-charts-with-inverted-range-top-down.svelte
@@ -5,10 +5,11 @@
 	import { getHydro } from '$lib/data.remote.js';
 
 	const data = await getHydro();
+
 	export { data };
 </script>
 
-<div class="grid grid-stack p-4 border rounded-sm">
+<div class="grid grid-stack p-2">
 	<!-- First chart with inverted yRange (top down) -->
 	<BarChart
 		{data}


### PR DESCRIPTION
- padding fixes
- "compound-common-scale-with-extra-marks" used timeDay for xInterval to keep from too condensed text