### PR TITLE
Fix choropleth example

### DIFF
--- a/packages/layerchart/src/routes/docs/examples/Choropleth/+page.svelte
+++ b/packages/layerchart/src/routes/docs/examples/Choropleth/+page.svelte
@@ -114,7 +114,7 @@
           />
           <Tooltip.Item
             label="Est. Percent under 18"
-            value={d?.percentUnder18 ?? 0 / 100}
+            value={d ? d.percentUnder18 / 100 : 0}
             format="percentRound"
             valueAlign="right"
           />


### PR DESCRIPTION
Fixes #687 by switching away from wrongly implemented nullish coalescing operator. As is, it always returns the value from the left side of `??` unchanged. Only if that value is ever `null/undefined` it'll return `0/100` from the right side which evaluates to just `0`.

This makes sure that the left side value is divided by 100 before being formatted.

There are probably a couple different ways to do this, so this is just one that seems simple and effective. Feel free to edit for best fit in your case. And I think the new docs carry over this error, so those will need fixed, too.

<img width="272" height="164" alt="Screenshot 2025-11-21 at 2 05 28 PM" src="https://github.com/user-attachments/assets/748b0aa1-b489-41b8-93e5-fdd2adb12ebb" />
