### PR TITLE
BarChart/Series-diverging xPadding

### DIFF
--- a/docs/src/examples/BarChart/series-horizontal-diverging-as-percent.svelte
+++ b/docs/src/examples/BarChart/series-horizontal-diverging-as-percent.svelte
@@ -35,6 +35,7 @@
 	y="age"
 	orientation="horizontal"
 	padding={{ left: 32, bottom: 16 }}
+	xPadding={[50, 50]}
 	labels={{ format: (value) => format(Math.abs(value), 'percent') }}
 	props={{
 		xAxis: { format: (value) => format(Math.abs(value), 'percentRound') }

--- a/docs/src/examples/BarChart/series-horizontal-diverging.svelte
+++ b/docs/src/examples/BarChart/series-horizontal-diverging.svelte
@@ -35,6 +35,7 @@
 	y="age"
 	orientation="horizontal"
 	padding={{ left: 32, bottom: 16 }}
+	xPadding={[5, 5]}
 	labels={{ format: (value) => format(Math.abs(value), 'metric') }}
 	props={{
 		xAxis: { format: (value) => format(Math.abs(value), 'metric') }


### PR DESCRIPTION
bar labels were overlapping axis labels for top/widest bar so gave them some room.