### PR TITLE
BarChart/group-series-padding bandPadding

### DIFF
--- a/docs/src/examples/BarChart/group-series-labels.svelte
+++ b/docs/src/examples/BarChart/group-series-labels.svelte
@@ -26,6 +26,7 @@
 		}
 	]}
 	seriesLayout="group"
+	bandPadding={0.2}
 	props={{
 		xAxis: { format: 'none' },
 		yAxis: { format: 'metric' },


### PR DESCRIPTION
band were narrow enough where labels at top were nearly colliding, made bands wider with padding.