### PR TITLE
BarChart/sparkbars

### DIFF
--- a/docs/src/examples/BarChart/sparkbar-fixed-position-tooltip.svelte
+++ b/docs/src/examples/BarChart/sparkbar-fixed-position-tooltip.svelte
@@ -32,7 +32,7 @@
 					{format(data.date, 'day')}
 				</div>
 				<div class="font-semibold">
-					{data.value}
+					{format(data.value, 'decimal')}
 				</div>
 			{/snippet}
 		</Tooltip.Root>

--- a/docs/src/examples/BarChart/sparkbar-within-a-paragraph-with-tooltip-and-highlight.svelte
+++ b/docs/src/examples/BarChart/sparkbar-within-a-paragraph-with-tooltip-and-highlight.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import { BarChart, Tooltip } from 'layerchart';
 	import { createDateSeries } from '$lib/utils/data.js';
+	import { format } from '@layerstack/utils';
 
 	const data = createDateSeries({ count: 30, min: 20, max: 100 });
 	export { data };
@@ -26,7 +27,7 @@
 				{#snippet children({ data })}
 					<Tooltip.Header value={data.date} format="day" />
 					<Tooltip.List>
-						<Tooltip.Item label="value" value={data.value} />
+						<Tooltip.Item label="value" value={format(data.value, 'decimal')} />
 					</Tooltip.List>
 				{/snippet}
 			</Tooltip.Root>


### PR DESCRIPTION
- "Sparkbar-fixed-position tooltip" - use format so not so many decimals.
- "sparkbar-within-a-paragraph-with-tooltip-and-highlight" - same reduction of decimals.