### PR TITLE
ScatterChart Padding

### DIFF
--- a/docs/src/examples/components/ScatterChart/basic.svelte
+++ b/docs/src/examples/components/ScatterChart/basic.svelte
@@ -6,4 +6,4 @@
 	export { data };
 </script>
 
-<ScatterChart {data} x="x" y="y" padding={24} height={400} />
+<ScatterChart {data} xNice x="x" y="y" padding={24} height={400} />

--- a/docs/src/examples/components/ScatterChart/brush.svelte
+++ b/docs/src/examples/components/ScatterChart/brush.svelte
@@ -8,6 +8,7 @@
 
 <ScatterChart
 	{data}
+	xNice
 	x="x"
 	y="y"
 	props={{

--- a/docs/src/examples/components/ScatterChart/custom-tooltip.svelte
+++ b/docs/src/examples/components/ScatterChart/custom-tooltip.svelte
@@ -7,7 +7,7 @@
 	export { data };
 </script>
 
-<ScatterChart {data} x="x" y="y" padding={24} height={400}>
+<ScatterChart {data} xNice x="x" y="y" padding={24} height={400}>
 	{#snippet tooltip({ context })}
 		<Tooltip.Root
 			x={context.padding.left}

--- a/docs/src/examples/components/ScatterChart/custom.svelte
+++ b/docs/src/examples/components/ScatterChart/custom.svelte
@@ -7,7 +7,7 @@
 	export { data };
 </script>
 
-<ScatterChart {data} x="x" y="y" padding={24} height={400}>
+<ScatterChart {data} xNice x="x" y="y" padding={24} height={400}>
 	{#snippet children({ context })}
 		<Layer>
 			<Axis placement="left" grid rule />

--- a/docs/src/examples/components/ScatterChart/date-series-color-scale.svelte
+++ b/docs/src/examples/components/ScatterChart/date-series-color-scale.svelte
@@ -9,6 +9,7 @@
 
 <ScatterChart
 	{data}
+	xNice
 	x="date"
 	y="value"
 	yBaseline={0}

--- a/docs/src/examples/components/ScatterChart/domain-nice.svelte
+++ b/docs/src/examples/components/ScatterChart/domain-nice.svelte
@@ -1,10 +1,16 @@
 <script lang="ts">
 	import { ScatterChart } from 'layerchart';
 	import { getSpiral } from '$lib/utils/data.js';
-	import Blockquote from '$lib/components/Blockquote.svelte';
 
 	const data = getSpiral({ angle: 137.5, radius: 10, count: 100, width: 500, height: 500 });
+
+	let applyNice = $state(true);
+	setInterval(() => {
+		applyNice = !applyNice;
+	}, 5000);
+
 	export { data };
 </script>
 
-<ScatterChart {data} x="x" y="y" xNice yNice padding={24} height={400} />
+{applyNice ? 'Applying Nice' : 'Not applying Nice'}
+<ScatterChart {data} x="x" y="y" xNice={applyNice} yNice={applyNice} padding={24} height={400} />

--- a/docs/src/examples/components/ScatterChart/labels.svelte
+++ b/docs/src/examples/components/ScatterChart/labels.svelte
@@ -6,4 +6,4 @@
 	export { data };
 </script>
 
-<ScatterChart {data} x="x" y="y" labels padding={24} height={400} />
+<ScatterChart {data} xNice x="x" y="y" labels padding={24} height={400} />

--- a/docs/src/examples/components/ScatterChart/line-annotation.svelte
+++ b/docs/src/examples/components/ScatterChart/line-annotation.svelte
@@ -8,6 +8,7 @@
 
 <ScatterChart
 	{data}
+	xNice
 	x="x"
 	y="y"
 	annotations={[

--- a/docs/src/examples/components/ScatterChart/point-annotations.svelte
+++ b/docs/src/examples/components/ScatterChart/point-annotations.svelte
@@ -8,6 +8,7 @@
 
 <ScatterChart
 	{data}
+	xNice
 	x="x"
 	y="y"
 	annotations={[

--- a/docs/src/examples/components/ScatterChart/range-annotation-both.svelte
+++ b/docs/src/examples/components/ScatterChart/range-annotation-both.svelte
@@ -8,6 +8,7 @@
 
 <ScatterChart
 	{data}
+	xNice
 	x="x"
 	y="y"
 	annotations={[

--- a/docs/src/examples/components/ScatterChart/range-annotation-horizontal.svelte
+++ b/docs/src/examples/components/ScatterChart/range-annotation-horizontal.svelte
@@ -8,6 +8,7 @@
 
 <ScatterChart
 	{data}
+	xNice
 	x="x"
 	y="y"
 	annotations={[

--- a/docs/src/examples/components/ScatterChart/range-annotation-vertical.svelte
+++ b/docs/src/examples/components/ScatterChart/range-annotation-vertical.svelte
@@ -8,6 +8,7 @@
 
 <ScatterChart
 	{data}
+	xNice
 	x="x"
 	y="y"
 	annotations={[

--- a/docs/src/examples/components/ScatterChart/series-custom-labels.svelte
+++ b/docs/src/examples/components/ScatterChart/series-custom-labels.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { ScatterChart } from 'layerchart';
+	import { ScatterChart, defaultChartPadding } from 'layerchart';
 	import { getPenguins } from '$lib/data.remote';
 	import { flatGroup } from 'd3-array';
 
@@ -15,6 +15,7 @@
 </script>
 
 <ScatterChart
+	xNice
 	x="flipper_length_mm"
 	y="bill_length_mm"
 	series={data.map(([species, data], i) => {
@@ -22,6 +23,7 @@
 		return {
 			key: species,
 			label: species + ' 🐧',
+			fontSize: 16,
 			data,
 			color,
 			props: {
@@ -31,6 +33,6 @@
 		};
 	})}
 	legend
-	padding={{ left: 10, top: 10, right: 10, bottom: 48 }}
+	padding={{ ...defaultChartPadding, top: 20, bottom: 48, left: 20, right: 20 }}
 	height={400}
 />

--- a/docs/src/examples/components/ScatterChart/series-legend.svelte
+++ b/docs/src/examples/components/ScatterChart/series-legend.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { ScatterChart } from 'layerchart';
+	import { ScatterChart, defaultChartPadding } from 'layerchart';
 	import { getPenguins } from '$lib/data.remote';
 	import { flatGroup } from 'd3-array';
 
@@ -15,6 +15,7 @@
 </script>
 
 <ScatterChart
+	xNice
 	x="flipper_length_mm"
 	y="bill_length_mm"
 	series={data.map(([species, data], i) => {
@@ -30,6 +31,6 @@
 		};
 	})}
 	legend
-	padding={{ left: 10, top: 10, right: 10, bottom: 48 }}
+	padding={{ ...defaultChartPadding, top: 20, bottom: 48, left: 20, right: 20 }}
 	height={400}
 />

--- a/docs/src/examples/components/ScatterChart/series-tween.svelte
+++ b/docs/src/examples/components/ScatterChart/series-tween.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { ScatterChart } from 'layerchart';
+	import { ScatterChart, defaultChartPadding } from 'layerchart';
 	import { getPenguins } from '$lib/data.remote';
 	import { flatGroup } from 'd3-array';
 
@@ -15,6 +15,7 @@
 </script>
 
 <ScatterChart
+	xNice
 	x="flipper_length_mm"
 	y="bill_length_mm"
 	series={data.map(([species, data], i) => {
@@ -36,6 +37,6 @@
 		grid: { motion: { type: 'tween', duration: 200 } },
 		points: { motion: { type: 'tween', duration: 200 } }
 	}}
-	padding={{ left: 10, top: 10, right: 10, bottom: 48 }}
+	padding={{ ...defaultChartPadding, top: 20, bottom: 48, left: 20, right: 20 }}
 	height={400}
 />

--- a/docs/src/examples/components/ScatterChart/series-with-radius.svelte
+++ b/docs/src/examples/components/ScatterChart/series-with-radius.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { ScatterChart } from 'layerchart';
+	import { defaultChartPadding, ScatterChart } from 'layerchart';
 	import { getPenguins } from '$lib/data.remote';
 	import { flatGroup } from 'd3-array';
 
@@ -15,6 +15,7 @@
 </script>
 
 <ScatterChart
+	xNice
 	x="flipper_length_mm"
 	y="bill_length_mm"
 	r="body_mass_g"
@@ -31,6 +32,6 @@
 			}
 		};
 	})}
-	padding={10}
+	padding={{ ...defaultChartPadding, top: 20, bottom: 20, left: 20, right: 20 }}
 	height={400}
 />

--- a/docs/src/examples/components/ScatterChart/series.svelte
+++ b/docs/src/examples/components/ScatterChart/series.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { ScatterChart } from 'layerchart';
+	import { ScatterChart, defaultChartPadding } from 'layerchart';
 	import { getPenguins } from '$lib/data.remote';
 	import { flatGroup } from 'd3-array';
 
@@ -15,6 +15,7 @@
 </script>
 
 <ScatterChart
+	xNice
 	x="flipper_length_mm"
 	y="bill_length_mm"
 	series={data.map(([species, data], i) => {
@@ -29,6 +30,6 @@
 			}
 		};
 	})}
-	padding={10}
+	padding={{ ...defaultChartPadding, top: 20, bottom: 20, left: 20, right: 20 }}
 	height={400}
 />

--- a/docs/src/examples/components/ScatterChart/single-axis-y.svelte
+++ b/docs/src/examples/components/ScatterChart/single-axis-y.svelte
@@ -6,4 +6,4 @@
 	export { data };
 </script>
 
-<ScatterChart {data} x="x" y="y" axis="y" padding={24} height={400} />
+<ScatterChart {data} xNice x="x" y="y" axis="y" padding={24} height={400} />

--- a/docs/src/examples/components/ScatterChart/tooltip-click.svelte
+++ b/docs/src/examples/components/ScatterChart/tooltip-click.svelte
@@ -8,6 +8,7 @@
 
 <ScatterChart
 	{data}
+	xNice
 	x="x"
 	y="y"
 	onTooltipClick={(e, detail) => {


### PR DESCRIPTION
- used  ...defaultChartPadding as basis then added needed custom padding. I did not update examples already customzing padding correctly like padding={{24}}

- also added xNice to many examples to prevent data from crashing into yAxis

- "Domain nice" Example added toggling on/off nice to illustrate effect better.