### PR TITLE
marker-controls-fix

### DIFF
--- a/docs/src/examples/components/Marker/orientation.svelte
+++ b/docs/src/examples/components/Marker/orientation.svelte
@@ -7,9 +7,6 @@
 	let config = $state({
 		show: true,
 		tweened: true,
-		markerStart: true,
-		markerMid: false,
-		markerEnd: true,
 		pathGenerator: (x: number) => x,
 		curve: undefined as ComponentProps<typeof CurveMenuField>['value'],
 		pointCount: 10,

--- a/docs/src/examples/components/Marker/spline.svelte
+++ b/docs/src/examples/components/Marker/spline.svelte
@@ -7,7 +7,6 @@
 	let config = $state({
 		show: true,
 		markerStart: true,
-		markerMid: false,
 		markerEnd: true,
 		tweened: true,
 		pathGenerator: (x: number) => x,
@@ -45,7 +44,6 @@
 						curve={config.curve}
 						class="stroke-primary"
 						markerStart={config.markerStart ? marker : undefined}
-						markerMid={config.markerMid ? marker : undefined}
 						markerEnd={config.markerEnd ? marker : undefined}
 						{motion}
 					/>

--- a/docs/src/examples/components/Marker/styling.svelte
+++ b/docs/src/examples/components/Marker/styling.svelte
@@ -7,9 +7,6 @@
 	let config = $state({
 		show: true,
 		tweened: true,
-		markerStart: true,
-		markerMid: false,
-		markerEnd: true,
 		pathGenerator: (x: number) => x,
 		curve: undefined as ComponentProps<typeof CurveMenuField>['value'],
 		pointCount: 10,


### PR DESCRIPTION
the same controls are used for many marker examples. Some need start/mid/end controls, others do not. Fixed them appropriately.