### PR TITLE
colorramp-update

### DIFF
--- a/docs/src/content/components/ColorRamp.md
+++ b/docs/src/content/components/ColorRamp.md
@@ -13,12 +13,12 @@ related: []
 
 ### Basic
 
-<Example name="basic" />
+<Example name="basic" noResize />
 
 ### Pixelated
 
-<Example name="pixelated" />
+<Example name="pixelated" noResize />
 
 ### Schemes
 
-<Example name="schemes" />
+<Example name="schemes" noResize />

--- a/docs/src/examples/components/ColorRamp/basic.svelte
+++ b/docs/src/examples/components/ColorRamp/basic.svelte
@@ -16,7 +16,7 @@
 	interpolators.push([`interpolateHclLong('red', 'blue')`, interpolateHclLong('red', 'blue')]);
 </script>
 
-<div class="grid gap-4 h-100 overflow-auto">
+<div class="grid gap-4 h-100 overflow-auto pr-2">
 	{#each interpolators as [name, interpolator]}
 		<div>
 			<div class="text-sm">{name}</div>

--- a/docs/src/examples/components/ColorRamp/pixelated.svelte
+++ b/docs/src/examples/components/ColorRamp/pixelated.svelte
@@ -20,7 +20,7 @@
 
 <StepsControl bind:steps />
 
-<div class="grid gap-4 h-100 overflow-auto">
+<div class="grid gap-4 h-100 overflow-auto pr-2">
 	{#each interpolators as [name, interpolator]}
 		<div>
 			<div class="text-sm">{name}</div>

--- a/docs/src/examples/components/ColorRamp/schemes.svelte
+++ b/docs/src/examples/components/ColorRamp/schemes.svelte
@@ -12,7 +12,7 @@
 	) as unknown as Array<[name: string, scheme: string[]]>;
 </script>
 
-<div class="grid gap-4 h-100 overflow-auto">
+<div class="grid gap-4 h-100 overflow-auto pr-2">
 	{#each schemes as [name, scheme]}
 		{#if typeof scheme[0] === 'string'}
 			<div>

--- a/docs/src/lib/components/Example.svelte
+++ b/docs/src/lib/components/Example.svelte
@@ -70,7 +70,7 @@
 
 	let canResize = $derived.by(() => {
 		// Prop
-		if (noResize) {
+		if (typeof noResize === 'boolean') {
 			return !noResize;
 		}
 


### PR DESCRIPTION
- fix for <Example />, allowing noResize to work
- added noResize for all coloramp examples
- added slight pr-2 for all coloramp examples to separate from scrollbar.