### PR TITLE
Replace lodash-es get/memoize with native equivalents

### DIFF
--- a/.changeset/replace-lodash-es-native.md
+++ b/.changeset/replace-lodash-es-native.md
@@ -1,0 +1,5 @@
+---
+"layerchart": patch
+---
+
+Replace lodash-es get/memoize with native equivalents

--- a/packages/layerchart/src/lib/utils/canvas.ts
+++ b/packages/layerchart/src/lib/utils/canvas.ts
@@ -1,5 +1,4 @@
 import { cls } from '@layerstack/tailwind';
-import { memoize } from 'lodash-es';
 import type { ClassValue } from 'svelte/elements';
 
 export const DEFAULT_FILL = 'rgb(0, 0, 0)';
@@ -289,9 +288,9 @@ export function _createLinearGradient(
 }
 
 /** Create linear gradient and memoize result to fix reactivity */
-export const createLinearGradient = memoize(
-  _createLinearGradient,
-  (
+export const createLinearGradient = (() => {
+  const cache = new Map<string, CanvasGradient>();
+  return (
     ctx: CanvasRenderingContext2D,
     x0: number,
     y0: number,
@@ -300,9 +299,12 @@ export const createLinearGradient = memoize(
     stops: { offset: number; color: string }[]
   ) => {
     const key = JSON.stringify({ x0, y0, x1, y1, stops });
-    return key;
-  }
-);
+    if (cache.has(key)) return cache.get(key)!;
+    const result = _createLinearGradient(ctx, x0, y0, x1, y1, stops);
+    cache.set(key, result);
+    return result;
+  };
+})();
 
 export function getPixelColor(ctx: CanvasRenderingContext2D, x: number, y: number) {
   const dpr = window.devicePixelRatio ?? 1;

--- a/packages/layerchart/src/lib/utils/common.ts
+++ b/packages/layerchart/src/lib/utils/common.ts
@@ -1,8 +1,20 @@
 import type { ComponentProps } from 'svelte';
-import { get } from 'lodash-es';
 
 import type Chart from '../components/Chart.svelte';
 import type LineChart from '../components/charts/LineChart.svelte';
+
+/** Resolve a dot/bracket path (e.g. `'a.b'`, `'arr[0]'`) on an object. */
+function getByPath(obj: any, path: string | number): any {
+  if (obj == null) return undefined;
+  if (typeof path === 'number') return obj[path];
+
+  const keys = path.replace(/\[(\w+)\]/g, '.$1').split('.');
+  let result: any = obj;
+  for (const key of keys) {
+    result = result?.[key];
+  }
+  return result;
+}
 
 export type Accessor<TData = any> =
   | number
@@ -20,7 +32,7 @@ export function accessor<TData = any>(prop: Accessor<TData>): (d: TData) => any 
     return prop;
   } else if (typeof prop === 'string' || typeof prop === 'number') {
     // path string or number (array index)
-    return (d: TData) => get(d, prop);
+    return (d: TData) => getByPath(d, prop);
   } else {
     // return full object
     return (d: TData) => d;

--- a/packages/layerchart/src/lib/utils/object.ts
+++ b/packages/layerchart/src/lib/utils/object.ts
@@ -1,6 +1,9 @@
-import { memoize } from 'lodash-es';
-
-export const memoizeObject = memoize(
-  (obj) => obj,
-  (obj) => JSON.stringify(obj)
-);
+export const memoizeObject = (() => {
+  const cache = new Map<string, any>();
+  return (obj: any) => {
+    const key = JSON.stringify(obj);
+    if (cache.has(key)) return cache.get(key);
+    cache.set(key, obj);
+    return obj;
+  };
+})();

--- a/packages/layerchart/src/lib/utils/string.ts
+++ b/packages/layerchart/src/lib/utils/string.ts
@@ -1,5 +1,3 @@
-import { memoize } from 'lodash-es';
-
 const MEASUREMENT_ELEMENT_ID = '__text_measurement_id';
 
 function _getStringWidth(str: string, style?: CSSStyleDeclaration) {
@@ -29,10 +27,16 @@ function _getStringWidth(str: string, style?: CSSStyleDeclaration) {
   }
 }
 
-export const getStringWidth = memoize(
-  _getStringWidth,
-  (str, style) => `${str}_${JSON.stringify(style)}`
-);
+export const getStringWidth = (() => {
+  const cache = new Map<string, ReturnType<typeof _getStringWidth>>();
+  return (str: string, style?: CSSStyleDeclaration) => {
+    const key = `${str}_${JSON.stringify(style)}`;
+    if (cache.has(key)) return cache.get(key)!;
+    const result = _getStringWidth(str, style);
+    cache.set(key, result);
+    return result;
+  };
+})();
 
 export type RasterizeTextOptions = {
   fontSize?: string;


### PR DESCRIPTION
## Summary

Replaces `lodash-es` `get` and `memoize` with native JavaScript equivalents to reduce the bundle size, per #616.

- `get` is replaced with a small `getByPath` helper that supports dot-separated paths (`obj.value`), bracket notation (`arr[0]`), and numeric indices
- `memoize` is replaced with inline `Map`-based caches that preserve the same resolver/key logic from each call site
- `merge` is intentionally kept — it has complex deep-merge semantics that are safer to leave as-is

## Changes

- `packages/layerchart/src/lib/utils/common.ts` — replace `get` import with local `getByPath` helper
- `packages/layerchart/src/lib/utils/string.ts` — replace `memoize` with Map-based cache (IIFE)
- `packages/layerchart/src/lib/utils/object.ts` — replace `memoize` with Map-based cache (IIFE)
- `packages/layerchart/src/lib/utils/canvas.ts` — replace `memoize` with Map-based cache (IIFE)

## Testing

- All 19 existing unit tests pass (including `accessor` tests covering nested paths, bracket notation, and numeric indices)
- `prettier --check .` passes with zero issues
- `svelte-check` passes with zero errors and zero warnings

Addresses #616