### PR TITLE
Add squares to markers

### DIFF
--- a/.changeset/five-stamps-drum.md
+++ b/.changeset/five-stamps-drum.md
@@ -1,0 +1,5 @@
+---
+'layerchart': patch
+---
+
+feat(Marker): Add `square` and `square-stroke` types

--- a/docs/src/examples/components/Marker/line.svelte
+++ b/docs/src/examples/components/Marker/line.svelte
@@ -17,7 +17,7 @@
 		})
 	);
 
-	const markerTypes = ['arrow', 'triangle', 'dot', 'circle', 'circle-stroke', 'line'] as const;
+	const markerTypes = ['arrow', 'triangle', 'dot', 'circle', 'circle-stroke', 'line', 'square', 'square-stroke'] as const;
 	export { data };
 </script>
 

--- a/docs/src/examples/components/Marker/spline.svelte
+++ b/docs/src/examples/components/Marker/spline.svelte
@@ -17,7 +17,7 @@
 		phase: 0
 	});
 
-	const markerTypes = ['arrow', 'triangle', 'dot', 'circle', 'circle-stroke', 'line'] as const;
+	const markerTypes = ['arrow', 'triangle', 'dot', 'circle', 'circle-stroke', 'line', 'square', 'square-stroke'] as const;
 
 	const motion = $derived(config.tweened ? 'tween' : 'none');
 	const data = $derived(

--- a/packages/layerchart/src/lib/components/Marker.svelte
+++ b/packages/layerchart/src/lib/components/Marker.svelte
@@ -8,7 +8,7 @@
      *
      * Pass `children` to render a custom element/component inside the marker instead.
      */
-    type?: 'arrow' | 'triangle' | 'line' | 'circle' | 'circle-stroke' | 'dot';
+    type?: 'arrow' | 'triangle' | 'line' | 'circle' | 'circle-stroke' | 'dot' | 'square' | 'square-stroke';
 
     /**
      * Unique identifier for the marker
@@ -117,6 +117,8 @@
       <circle cx={5} cy={5} r={5} class="lc-marker-circle" />
     {:else if type === 'line'}
       <polyline points="5 0, 5 10" class="lc-marker-line" />
+    {:else if type === 'square' || type === 'square-stroke'}
+      <rect x={0} y={0} width={10} height={10} class="lc-marker-square" />
     {/if}
   </marker>
 </defs>
@@ -128,6 +130,7 @@
 
       &[data-type='arrow'],
       &[data-type='circle-stroke'],
+      &[data-type='square-stroke'],
       &[data-type='line'] {
         fill: none;
         stroke: context-stroke;
@@ -141,11 +144,13 @@
 
       &[data-type='triangle'],
       &[data-type='dot'],
-      &[data-type='circle'] {
+      &[data-type='circle'],
+      &[data-type='square'] {
         fill: context-stroke;
       }
 
-      &[data-type='circle-stroke'] {
+      &[data-type='circle-stroke'],
+      &[data-type='square-stroke'] {
         fill: var(--color-surface-100, light-dark(white, black));
       }
     }


### PR DESCRIPTION
Documenation listed squares as an option, but this did not exits. I have added 'square' and 'square-stroke' as options. I have also updated line and spline examples to illustrate it.