### PR TITLE
fix(TooltipContext): correct `bisect-band` hit detection

### DIFF
--- a/.changeset/metal-flowers-sneeze.md
+++ b/.changeset/metal-flowers-sneeze.md
@@ -1,0 +1,5 @@
+---
+'layerchart': patch
+---
+
+fix(TooltipContext): correct `bisect-band` hit detection by accounting for chart padding

--- a/packages/layerchart/src/lib/components/tooltip/TooltipContext.svelte
+++ b/packages/layerchart/src/lib/components/tooltip/TooltipContext.svelte
@@ -310,8 +310,8 @@
 
         case 'bisect-band': {
           // `x` and `y` values at pointer coordinate
-          const xValueAtPoint = scaleInvert(ctx.xScale, point.x);
-          const yValueAtPoint = scaleInvert(ctx.yScale, point.y);
+          const xValueAtPoint = scaleInvert(ctx.xScale, point.x - ctx.padding.left);
+          const yValueAtPoint = scaleInvert(ctx.yScale, point.y - ctx.padding.top);
 
           if (isScaleBand(ctx.xScale)) {
             // Find point closest to pointer within the x band


### PR DESCRIPTION
When using the tooltip with `mode="bisect-band"`, pointer coordinates were not adjusted for chart padding. As a result, the tooltip could snap to the wrong data point whenever left or top padding was present.

`bisect-x` and `bisect-y` modes already subtract `ctx.padding.left` and `ctx.padding.top` correctly. This PR applies the same offsets to `bisect-band`.