### PR TITLE
strong-webkit-fix

### DIFF
--- a/docs/src/app.css
+++ b/docs/src/app.css
@@ -36,6 +36,10 @@
 		border-color: color-mix(in oklab, var(--color-surface-content) 20%, transparent);
 		outline-color: color-mix(in oklab, var(--color-surface-content) 20%, transparent);
 	}
+	strong {
+		color: currentColor !important; /* webkit fix for 'text-initial'  */
+		font-weight: 800 !important;
+	}
 }
 
 @layer utilities {


### PR DESCRIPTION
Currently `<strong>`text elements rendering dark Safari in darkmode. Webkit treats color: initial on inline replaced/formatted elements differently than Chrome/Firefox. The most reliable fix is avoiding inherit entirely and just setting an explicit color directly

Example [Transform - Pointer Interactions (b/w * and -)](https://next.layerchart.com/docs/guides/transform#pointer-interactions)

Fix has been tested for dark and light modes in Safari, Chrome, Firefox.