### PR TITLE
Delay screenshots motion

### DIFF
--- a/docs/scripts/generate-screenshots.ts
+++ b/docs/scripts/generate-screenshots.ts
@@ -218,7 +218,7 @@ async function captureScreenshots(
 		await page.waitForLoadState('domcontentloaded');
 
 		// wait if the lazy-loaded element found
-		if (document.querySelectorAll('lazy-loaded')) {
+		if (document.querySelectorAll('screenshot-delay')) {
 			await new Promise((resolve) => setTimeout(resolve, 2000));
 		}
 

--- a/docs/scripts/generate-screenshots.ts
+++ b/docs/scripts/generate-screenshots.ts
@@ -214,6 +214,14 @@ async function captureScreenshots(
 		// Navigate to the example
 		await page.goto(url, { waitUntil: 'networkidle' });
 
+		// wait for the page to be ready
+		await page.waitForLoadState('domcontentloaded');
+
+		// wait if the lazy-loaded element found
+		if (document.querySelectorAll('lazy-loaded')) {
+			await new Promise((resolve) => setTimeout(resolve, 2000));
+		}
+
 		// Hide example controls before taking screenshots
 		await page.evaluate(() => {
 			const controls = document.querySelectorAll('.screenshot-hidden');

--- a/docs/src/lib/components/controls/fields/ShowField.svelte
+++ b/docs/src/lib/components/controls/fields/ShowField.svelte
@@ -27,7 +27,10 @@
 </script>
 
 {#if !inline}
-	<div bind:this={target} class="grid grid-cols-[auto_1fr] gap-2 mb-3 screenshot-hidden">
+	<div
+		bind:this={target}
+		class="grid grid-cols-[auto_1fr] gap-2 mb-3 screenshot-hidden lazy-loaded"
+	>
 		<Field {label} {labelPlacement} let:id class={className}>
 			<Switch bind:checked={show} size="md" />
 		</Field>

--- a/docs/src/lib/components/controls/fields/ShowField.svelte
+++ b/docs/src/lib/components/controls/fields/ShowField.svelte
@@ -29,7 +29,7 @@
 {#if !inline}
 	<div
 		bind:this={target}
-		class="grid grid-cols-[auto_1fr] gap-2 mb-3 screenshot-hidden lazy-loaded"
+		class="grid grid-cols-[auto_1fr] gap-2 mb-3 screenshot-hidden screenshot-delay"
 	>
 		<Field {label} {labelPlacement} let:id class={className}>
 			<Switch bind:checked={show} size="md" />


### PR DESCRIPTION
since adding lazy loaded charts which contain motion, screenshots for them are firing before they are rendered.

I added "screenshot-delay" class to showControl.svelte, and check for that in generate-screenshots.ts. If found introduce pause to allow them to fully render.