### PR TITLE
fix: Prevent submitting forms when clicking legend buttons

### DIFF
--- a/.changeset/all-papers-unite.md
+++ b/.changeset/all-papers-unite.md
@@ -2,4 +2,4 @@
 'layerchart': patch
 ---
 
-fix: Prevent clicking legend buttons from submitting forms
+fix: Prevent submitting forms when clicking legend buttons

--- a/.changeset/all-papers-unite.md
+++ b/.changeset/all-papers-unite.md
@@ -1,0 +1,5 @@
+---
+'layerchart': patch
+---
+
+fix: Prevent clicking legend buttons from submitting forms

--- a/packages/layerchart/src/lib/components/Legend.svelte
+++ b/packages/layerchart/src/lib/components/Legend.svelte
@@ -498,6 +498,7 @@
     <div class={cls('lc-legend-swatch-group', classes.items)} data-orientation={orientation}>
       {#each swatchItems as item}
         <button
+          type="button"
           class={cls('lc-legend-swatch-button', resolveMaybeFn(classes?.item, item))}
           style:opacity={selected.length === 0 || selected.includes(item.value) ? 1 : 0.3}
           onclick={(e) => onclickProp?.(e, item) ?? item.onclick?.(e)}


### PR DESCRIPTION
Kinda weird to have a chart inside of a form ik, I sure hope no one is intentionally submitting their forms with the legend.