### PR TITLE
fixed-height-md-tabs

### DIFF
--- a/docs/src/lib/markdown/components/Tab.svelte
+++ b/docs/src/lib/markdown/components/Tab.svelte
@@ -14,6 +14,7 @@
 
 	const tabsContext = getContext<{
 		activeTab: number;
+		hasHeight: boolean;
 		setActiveTab: (index: number) => void;
 		registerTab: (label: string | undefined, icon: Component | undefined) => number;
 	}>('tabs');

--- a/docs/src/lib/markdown/components/Tabs.svelte
+++ b/docs/src/lib/markdown/components/Tabs.svelte
@@ -23,9 +23,10 @@
 	interface Props extends HTMLAttributes<HTMLDivElement> {
 		children: Snippet;
 		key?: string;
+		height?: string;
 	}
 
-	const { children, key, class: className, ...restProps }: Props = $props();
+	const { children, key, class: className, height, ...restProps }: Props = $props();
 
 	// Use synced state if key is provided, otherwise use local state
 	let localActiveIndex = $state(0);
@@ -55,6 +56,9 @@
 	setContext('tabs', {
 		get activeTab() {
 			return activeTab;
+		},
+		get hasHeight() {
+			return !!height;
 		},
 		setActiveTab: (index: number) => {
 			if (syncedState) {
@@ -103,7 +107,38 @@
 	</div>
 
 	<!-- Tab content -->
-	<div class="border rounded-lg rounded-tl-none px-3 py-1 bg-surface-100">
+	<div
+		class={cls('border rounded-lg rounded-tl-none px-3 py-1 bg-surface-100', height && 'tabs-has-height overflow-y-scroll')}
+		style:height={height}
+	>
 		{@render children?.()}
 	</div>
 </div>
+
+<style>
+	.tabs-has-height {
+		display: flex;
+		flex-direction: column;
+	}
+	:global(.tabs-has-height .tab:not(.hidden)) {
+		flex: 1;
+		display: flex;
+		flex-direction: column;
+		min-height: 0;
+	}
+	/* rehype-pretty-code wraps code blocks in <figure> */
+	:global(.tabs-has-height .tab:not(.hidden) > figure) {
+		flex: 1;
+		display: flex;
+		flex-direction: column;
+		min-height: 0;
+	}
+	:global(.tabs-has-height .tab:not(.hidden) .pre-block) {
+		flex: 1;
+		min-height: 0;
+	}
+	:global(.tabs-has-height .tab:not(.hidden) .pre-block > pre) {
+		flex: 1;
+		min-height: 0;
+	}
+</style>

--- a/docs/src/lib/markdown/components/pre.svelte
+++ b/docs/src/lib/markdown/components/pre.svelte
@@ -49,7 +49,7 @@
 </script>
 
 <div
-	class="relative group rounded-lg outline outline-surface-content/20 dark:outline-surface-content/10 overflow-hidden my-2"
+	class="pre-block relative group rounded-lg outline outline-surface-content/20 dark:outline-surface-content/10 overflow-hidden my-2 flex flex-col"
 >
 	{#if dataTitle}
 		<div

--- a/docs/src/routes/docs/getting-started/+page.md
+++ b/docs/src/routes/docs/getting-started/+page.md
@@ -115,7 +115,7 @@ If you wish to apply darkmode defaults, see the [dark mode](/docs/guides/styles#
 
 or with a single `.css` import, Layerchart [provides](https://github.com/techniq/layerchart/tree/next/packages/layerchart/src/lib/styles) theming conventions for many popular UI frameworks.
 
-:::tabs{key="framework"}
+:::tabs{key="framework" height="185px"}
 
     ::tab{label="shadcn-svelte" icon="custom-brands:shadcnsvelte"}
     ```css title="app.css"
@@ -198,7 +198,7 @@ All set! Now just fire up the dev server and start iterating. Have fun!
 
 Starter [project repos](https://github.com/techniq/layerchart/tree/next/examples) are available for popular UI frameworks.
 
-:::tabs{key="framework"}
+:::tabs{key="framework" height="140px"}
 
     ::tab{label="shadcn-svelte" icon="custom-brands:shadcnsvelte"}
     [shadcn-svelte](https://www.shadcn-svelte.com/)


### PR DESCRIPTION
Add a height prop to the MDC :::tabs component to prevent layout shifts when switching between tabs with different content lengths.

Usage:
:::tabs{key="framework" height="185px"}