### PR TITLE
fix: guard against undefined accessor in printScale

### DIFF
--- a/.changeset/fix-debug-printscale.md
+++ b/.changeset/fix-debug-printscale.md
@@ -1,0 +1,7 @@
+---
+"layerchart": patch
+---
+
+fix: guard against undefined accessor in printScale
+
+When activeGetters includes z or r scales that are not configured, the accessor is undefined, causing acc.toString() to throw. Added null check.

--- a/packages/layerchart/src/lib/utils/debug.ts
+++ b/packages/layerchart/src/lib/utils/debug.ts
@@ -69,7 +69,7 @@ function colorizeArray(arr: RGBInput[]) {
 function printScale(s: string, scale: any, acc: any) {
   const scaleName = findScaleName(scale);
   console.log(`${indent}${s}:`);
-  console.log(`${indent}${indent}Accessor: "${acc.toString()}"`);
+  if (acc != null) console.log(`${indent}${indent}Accessor: "${acc.toString()}"`);
   console.log(`${indent}${indent}Type: ${scaleName}`);
   printValues(scale, 'domain');
   printValues(scale, 'range', ' ');


### PR DESCRIPTION
- [ ] Guard `acc` param in `printScale` to prevent crash when `z` or `r` scales are not configured but included in `activeGetters`

`activeGetters` always includes `x`, `y`, `z`, and `r` (see `chart.svelte.ts:617`), but when `z` or `r` are not configured, the accessor is `undefined`, causing `acc.toString()` to throw:

```
TypeError: can't access property "toString", acc is undefined
    printScale debug.ts:72
    printDebug debug.ts:100
```

Fix: add `if (acc != null)` guard before calling `acc.toString()`.