### PR TITLE
Add skeleton-5.css

### DIFF
--- a/.changeset/bold-cats-cry.md
+++ b/.changeset/bold-cats-cry.md
@@ -1,0 +1,5 @@
+---
+'layerchart': patch
+---
+
+Added skeleton-5.css

--- a/packages/layerchart/src/lib/styles/skeleton-5.css
+++ b/packages/layerchart/src/lib/styles/skeleton-5.css
@@ -6,7 +6,10 @@
   --color-surface-100: var(--color-surface-50-950);
   --color-surface-200: var(--color-surface-100);
   --color-surface-300: var(--color-surface-200);
-  --color-surface-content: var(--typo-base--color-dark);
+  --color-surface-content: light-dark(
+    var(--typo-base--color-light),
+    var(--typo-base--color-dark)
+  );
 
   html.dark & {
     --color-surface-100: var(--color-surface-700);

--- a/packages/layerchart/src/lib/styles/skeleton-5.css
+++ b/packages/layerchart/src/lib/styles/skeleton-5.css
@@ -15,6 +15,6 @@
     --color-surface-100: var(--color-surface-700);
     --color-surface-200: var(--color-surface-800);
     --color-surface-300: var(--color-surface-900);
-    --color-surface-content: var(--typo-base--color-light);
+    --color-surface-content: var(--typo-base--color-dark);
   }
 }

--- a/packages/layerchart/src/lib/styles/skeleton-5.css
+++ b/packages/layerchart/src/lib/styles/skeleton-5.css
@@ -1,0 +1,17 @@
+@import './core.css';
+
+.lc-root-container {
+  --color-primary: var(--color-primary-500);
+
+  --color-surface-100: var(--color-surface-50-950);
+  --color-surface-200: var(--color-surface-100);
+  --color-surface-300: var(--color-surface-200);
+  --color-surface-content: var(--typo-base--color-dark);
+
+  html.dark & {
+    --color-surface-100: var(--color-surface-700);
+    --color-surface-200: var(--color-surface-800);
+    --color-surface-300: var(--color-surface-900);
+    --color-surface-content: var(--typo-base--color-light);
+  }
+}


### PR DESCRIPTION
Related to #887. I have updated `--color-surface-content` to match the new version.
Note that I also changed `--color-surface-100` as the text is barely readable in dark mode with its default configuration. That may just be something I have to do on my own end though and could be excised from this PR.

Not included are the docs or additional example repos.

Before 
<img width="1415" height="508" alt="image" src="https://github.com/user-attachments/assets/c2b2c930-3aaf-4bb9-98fd-3bd2fe47f196" />

After
<img width="1437" height="491" alt="image" src="https://github.com/user-attachments/assets/db62e445-e1b4-421b-91af-4717ec0066de" />
